### PR TITLE
build: Configure eslint to disallow ES6 and make pass

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -2,8 +2,7 @@
 	"root": true,
 	"extends": [
 		"wikimedia/client",
-		"wikimedia/jquery",
-		"plugin:vue/recommended"
+		"wikimedia/jquery"
 	],
 	"globals": {
 		"mw": false,
@@ -12,18 +11,37 @@
 		"module": false
 	},
 	"rules": {
-		"vue/html-indent": [ "warn", "tab" ],
-		"vue/html-closing-bracket-newline": "off",
-		"vue/max-attributes-per-line": [ "warn", {
-			"singleline": 2,
-			"multiline": {
-				"max": 1,
-				"allowFirstLine": true
-			} 
-		} ],
-		"vue/v-on-style": [ "error", "longform" ],
-		"vue/v-bind-style": [ "error", "longform" ],
-		"vue/v-slot-style": [ "error", "longform" ],
 		"no-jquery/variable-pattern": "off"
-	}
+	},
+	"overrides": [
+		{
+			"files": [ "**/*.vue" ],
+			"extends": [
+				"plugin:vue/recommended",
+				"plugin:es/no-2015"
+			],
+			"plugins": [ "es" ],
+			"parserOptions": {
+				"sourceType": "script",
+				"ecmaFeatures": {
+					"jsx": false
+				}
+			},
+			"rules": {
+				"no-implicit-globals": 0,
+				"vue/html-indent": [ "warn", "tab" ],
+				"vue/html-closing-bracket-newline": "off",
+				"vue/max-attributes-per-line": [ "warn", {
+					"singleline": 2,
+					"multiline": {
+						"max": 1,
+						"allowFirstLine": true
+					}
+				} ],
+				"vue/v-on-style": [ "error", "longform" ],
+				"vue/v-bind-style": [ "error", "longform" ],
+				"vue/v-slot-style": [ "error", "longform" ]
+			}
+		}
+	]
 }

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -10,11 +10,11 @@ module.exports = function ( grunt ) {
 	grunt.initConfig( {
 		eslint: {
 			options: {
-				extensions: [ '.js', '.json' ],
+				extensions: [ '.js', '.json', '.vue' ],
 				cache: true
 			},
 			all: [
-				'**/*.{js,json}',
+				'**/*.{js,json,vue}',
 				'!{vendor,node_modules}/**'
 			]
 		},

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,5 +1,6 @@
-/* eslint-disable no-unused-vars */
-/* eslint-disable no-undef */
+/* eslint-disable no-implicit-globals */
+// eslint-disable-next-line no-redeclare
+/* global mw:true, jest:false, global:false */
 
 /**
  * Mock out a global mediawiki object for use in unit tests
@@ -9,6 +10,7 @@
  * The basic Jest mock functions here can be overridden with more specific
  * behavior as needed in individual test files.
  */
+// eslint-disable-next-line no-redeclare
 var mw;
 
 // Mock API (instances created ggwith new mw.Api() )

--- a/package-lock.json
+++ b/package-lock.json
@@ -2296,6 +2296,16 @@
 				"eslint-plugin-qunit": "^4.0.0"
 			}
 		},
+		"eslint-plugin-es": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-es/-/eslint-plugin-es-1.4.1.tgz",
+			"integrity": "sha512-5fa/gR2yR3NxQf+UXkeLeP8FBBl6tSgdrAz1+cF84v1FMM4twGwQoqTnn+QxFLcPOrF4pdKEJKDB/q9GoyJrCA==",
+			"dev": true,
+			"requires": {
+				"eslint-utils": "^1.4.2",
+				"regexpp": "^2.0.1"
+			}
+		},
 		"eslint-plugin-json": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/eslint-plugin-json/-/eslint-plugin-json-1.4.0.tgz",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
 		"@vue/test-utils": "^1.0.0-beta.32",
 		"babel-core": "^6.26.3",
 		"eslint-config-wikimedia": "0.15.0",
+		"eslint-plugin-es": "^1.2.0",
 		"eslint-plugin-vue": "^6.1.2",
 		"grunt": "1.0.4",
 		"grunt-banana-checker": "0.8.1",

--- a/resources/components/ImageCard.vue
+++ b/resources/components/ImageCard.vue
@@ -92,9 +92,11 @@ module.exports = {
 			suggestion.confirmed = !suggestion.confirmed;
 		},
 		onPublish: function () {
+			// eslint-disable-next-line no-console
 			console.log( 'On publish' );
 		},
 		onSkip: function () {
+			// eslint-disable-next-line no-console
 			console.log( 'On skip' );
 		}
 	}

--- a/resources/components/base/Button.vue
+++ b/resources/components/base/Button.vue
@@ -56,7 +56,7 @@ module.exports = {
 	},
 
 	computed: {
-		builtInClasses() {
+		builtInClasses: function () {
 			return {
 				'wbmad-button--framed': this.framed,
 				'wbmad-button--icon': this.icon,
@@ -65,7 +65,7 @@ module.exports = {
 				'wbmad-button--primary': this.primary
 			};
 		},
-		invert() {
+		invert: function () {
 			return ( this.primary || this.disabled && this.framed );
 		}
 	}

--- a/resources/components/base/Icon.vue
+++ b/resources/components/base/Icon.vue
@@ -20,7 +20,7 @@ module.exports = {
 	},
 
 	computed: {
-		builtInClasses() {
+		builtInClasses: function () {
 			// Use the existing OOUI classes for icon images for now.
 			var iconClass = 'oo-ui-icon-' + this.icon,
 				classes = { 'oo-ui-image-invert': this.invert };

--- a/resources/init.js
+++ b/resources/init.js
@@ -21,7 +21,7 @@
 	// eslint-disable-next-line no-new
 	new Vue( {
 		el: '#wbmad-app',
-		store,
+		store: store,
 		render: function ( h ) {
 			return h( App );
 		}

--- a/resources/models/ImageData.js
+++ b/resources/models/ImageData.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var ImageData = function WikibaseMachineAssistedDepictsImageData(
+module.exports = function WikibaseMachineAssistedDepictsImageData(
 	title,
 	pageid,
 	descriptionurl,
@@ -15,5 +15,3 @@ var ImageData = function WikibaseMachineAssistedDepictsImageData(
 	this.thumbheight = thumbheight;
 	this.suggestions = suggestions;
 };
-
-module.exports = ImageData;

--- a/resources/models/SuggestionData.js
+++ b/resources/models/SuggestionData.js
@@ -1,9 +1,7 @@
 'use strict';
 
-var SuggestionData = function WikibaseMachineAssistedDepictsSuggestionData( text, wikidataId ) {
+module.exports = function WikibaseMachineAssistedDepictsSuggestionData( text, wikidataId ) {
 	this.text = text;
 	this.wikidataId = wikidataId;
 	this.confirmed = false;
 };
-
-module.exports = SuggestionData;

--- a/resources/plugins/api.js
+++ b/resources/plugins/api.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-irregular-whitespace */
 'use strict';
 
 /**
@@ -11,7 +10,7 @@
  * More information about Vue plugins is available here:
  * https://vuejs.org/v2/guide/plugins.html
  */
-var apiPlugin = {
+module.exports = {
 	/**
 	 * @param {Object} Vue constructor
 	 * @param {Object} options
@@ -29,5 +28,3 @@ var apiPlugin = {
 		Vue.prototype.$api = Vue.api;
 	}
 };
-
-module.exports = apiPlugin;

--- a/resources/store/index.js
+++ b/resources/store/index.js
@@ -1,7 +1,9 @@
 'use strict';
 
+/* eslint-disable no-implicit-globals */
 var Vue = require( 'vue' ),
 	Vuex = require( 'vuex' ),
+	// eslint-disable-next-line no-redeclare
 	ImageData = require( '../models/ImageData.js' ),
 	SuggestionData = require( '../models/SuggestionData.js' ),
 	api,
@@ -239,7 +241,7 @@ module.exports = new Vuex.Store( {
 						image: image
 					} );
 				} );
-			} ).catch( function ( error ) {
+			} ).catch( function ( /* error */ ) {
 				// @TODO error handling logic
 			} );
 		},
@@ -254,7 +256,7 @@ module.exports = new Vuex.Store( {
 		 * @param {Object} context
 		 * @param {Object} payload
 		 */
-		publishTags: function ( context, payload ) {
+		publishTags: function ( /* context, payload */ ) {
 		},
 
 		/**

--- a/tests/jest/.eslintrc.json
+++ b/tests/jest/.eslintrc.json
@@ -2,6 +2,9 @@
 	"extends": [
 		"../../.eslintrc.json"
 	],
+	"parserOptions": {
+		"ecmaVersion": 6
+	},
 	"globals": {
 		"global": true,
 		"require": true
@@ -12,6 +15,7 @@
 		"one-var": "off"
 	},
 	"env": {
+		"es6": true,
 		"jest": true
 	}
 }


### PR DESCRIPTION
The vue plugin for eslint overrides ecmaVersion to 2018, sourceType to
"module", and enables jsx. We can undo the latter two in .eslintrc.json,
but setting ecmaVersion to 5 breaks the Vue plugin. Instead, use the es
plugin's es/no-2015 rule to prohibit ES6 syntax.

Also:
- Shut up no-implicit-globals warnings in .vue files (we should consider
  disabling this rule altogether in MediaWiki)
- Disable warning about ImageData already being a reserved name
  (we should consider renaming this model)