### PR TITLE
Enforce property order in components

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -38,6 +38,31 @@
 						"allowFirstLine": true
 					}
 				} ],
+				"vue/order-in-components": ["error", {
+					"order": [
+						"el",
+						"name",
+						"parent",
+						"functional",
+						["delimiters", "comments"],
+						["components", "directives", "filters"],
+						"extends",
+						"mixins",
+						"inheritAttrs",
+						"model",
+						["props", "propsData"],
+						"asyncData",
+						"data",
+						"computed",
+						"methods",
+						"watch",
+						"fetch",
+						"LIFECYCLE_HOOKS",
+						"head",
+						["template", "render"],
+						"renderError"
+					]
+				} ],
 				"vue/v-on-style": [ "error", "longform" ],
 				"vue/v-bind-style": [ "error", "longform" ],
 				"vue/v-slot-style": [ "error", "longform" ]

--- a/resources/components/App.vue
+++ b/resources/components/App.vue
@@ -69,6 +69,7 @@ var mapState = require( 'vuex' ).mapState,
 	Tab = require( './base/Tab.vue' ),
 	CardStack = require( './CardStack.vue' );
 
+// @vue/component
 module.exports = {
 	name: 'MachineVision',
 

--- a/resources/components/CardStack.vue
+++ b/resources/components/CardStack.vue
@@ -23,6 +23,7 @@ var mapState = require( 'vuex' ).mapState,
 	Spinner = require( './Spinner.vue' ),
 	ImageCard = require( './ImageCard.vue' );
 
+// @vue/component
 module.exports = {
 	name: 'CardStack',
 

--- a/resources/components/ImageCard.vue
+++ b/resources/components/ImageCard.vue
@@ -45,6 +45,7 @@
 <script>
 var Button = require( './base/Button.vue' );
 
+// @vue/component
 module.exports = {
 	name: 'ImageCard',
 

--- a/resources/components/Spinner.vue
+++ b/resources/components/Spinner.vue
@@ -5,6 +5,7 @@
 </template>
 
 <script>
+// @vue/component
 module.exports = {
 	name: 'Spinner'
 };

--- a/resources/components/base/Button.vue
+++ b/resources/components/base/Button.vue
@@ -17,6 +17,7 @@
 <script>
 var Icon = require( './Icon.vue' );
 
+// @vue/component
 module.exports = {
 	name: 'Button',
 

--- a/resources/components/base/Icon.vue
+++ b/resources/components/base/Icon.vue
@@ -6,6 +6,7 @@
 </template>
 
 <script>
+// @vue/component
 module.exports = {
 	name: 'Icon',
 	props: {

--- a/resources/components/base/Tab.vue
+++ b/resources/components/base/Tab.vue
@@ -5,6 +5,7 @@
 </template>
 
 <script>
+// @vue/component
 module.exports = {
 	name: 'Tab',
 	props: {

--- a/resources/components/base/Tabs.vue
+++ b/resources/components/base/Tabs.vue
@@ -16,6 +16,7 @@
 </template>
 
 <script>
+// @vue/component
 module.exports = {
 	name: 'Tabs',
 
@@ -38,15 +39,15 @@ module.exports = {
 		}
 	},
 
-	mounted: function () {
-		this.setTabState( this.selectedIndex );
-	},
-
 	watch: {
 		selectedIndex: function ( newIndex ) {
 			this.setTabState( newIndex );
 			this.$emit( 'tab-change', this.tabs[ this.selectedIndex ] );
 		}
+	},
+
+	mounted: function () {
+		this.setTabState( this.selectedIndex );
 	}
 };
 </script>


### PR DESCRIPTION
Add the @vue/component directive above each component definition so that
eslint recognizes them. Enforce the standard property order.