### PR TITLE
Add support for multiple image queues

### DIFF
--- a/resources/components/App.vue
+++ b/resources/components/App.vue
@@ -18,18 +18,16 @@
 			/>
 
 			<tabs v-on:tab-change="onTabChange">
-				<tab title="Popular">
-					<card-stack queue="popular" />
-				</tab>
-
-				<tab title="User">
-					<card-stack queue="user" />
+				<tab v-for="( tab, index ) in tabs"
+					v-bind:key="'tab-' + index"
+					v-bind:title="tab">
+					<card-stack v-bind:queue="tab" />
 				</tab>
 			</tabs>
 		</template>
 
 		<!-- Login message container -->
-		<template v-else-if="!user.isAuthenticated">
+		<template v-else-if="!isAuthenticated">
 			<!-- eslint-disable-next-line vue/no-v-html -->
 			<p v-html="loginMessage" />
 		</template>
@@ -68,6 +66,7 @@
  */
 
 var mapState = require( 'vuex' ).mapState,
+	mapGetters = require( 'vuex' ).mapGetters,
 	mapActions = require( 'vuex' ).mapActions,
 	Tabs = require( './base/Tabs.vue' ),
 	Tab = require( './base/Tab.vue' ),
@@ -83,29 +82,58 @@ module.exports = {
 		'card-stack': CardStack
 	},
 
-	computed: $.extend( {
+	computed: $.extend( {}, mapState( [
+		'success',
+		'error'
+	] ), mapGetters( [
+		'tabs',
+		'isAuthenticated',
+		'isAutoconfirmed'
+	] ), {
+		/**
+		 * Whether or not to display the full UI
+		 *
+		 * @return {bool}
+		 */
 		showTabs: function () {
-			return this.user.isAuthenticated && this.user.isAutoconfirmed;
+			return this.isAuthenticated && this.isAutoconfirmed;
 		},
+
+		/**
+		 * @TODO fix this message to not require server-side wikitext parsing
+		 * so that we can rely on the i18n plugin instead of depending on
+		 * mw.config here
+		 *
+		 * @return {string}
+		 */
 		loginMessage: function () {
 			return mw.config.get( 'wgMVSuggestedTagsLoginMessage' );
 		}
-	}, mapState( [
-		'tabs',
-		'pending',
-		'success',
-		'error',
-		'user'
-	] ) ),
+	} ),
 
 	methods: $.extend( {}, mapActions( [
 		'updateCurrentTab',
 		'getImages'
 	] ), {
+		/**
+		 * Watch the tab change events emitted by the <Tabs> component
+		 * to ensure that Vuex state is kept in sync
+		 *
+		 * @param {string} tab name
+		 */
 		onTabChange: function ( tab ) {
 			this.updateCurrentTab( tab.title.toLowerCase() );
 		}
-	} )
+	} ),
+
+	mounted: function () {
+		// popular images are pre-loaded on the server side;
+		// immediately fetch user images in the mounted hook so that they'll be
+		// ready for the user if they switch tabs
+		this.getImages( {
+			queue: 'user'
+		} );
+	}
 };
 </script>
 

--- a/resources/components/CardStack.vue
+++ b/resources/components/CardStack.vue
@@ -4,7 +4,7 @@
 			Showing image from {{ queue }} feed
 		</h3>
 
-		<wbmad-spinner v-if="pending" />
+		<wbmad-spinner v-if="isPending" />
 
 		<div v-else>
 			<div v-if="currentImage">
@@ -20,6 +20,7 @@
 
 <script>
 var mapState = require( 'vuex' ).mapState,
+	mapActions = require( 'vuex' ).mapActions,
 	Spinner = require( './Spinner.vue' ),
 	ImageCard = require( './ImageCard.vue' );
 
@@ -44,9 +45,47 @@ module.exports = {
 		'pending',
 		'images'
 	] ), {
+		/**
+		 * @return {Array}
+		 */
+		imagesInQueue: function () {
+			return this.images[ this.queue ];
+		},
+
+		/**
+		 * @return {Object|undefined}
+		 */
 		currentImage: function () {
-			return this.images[ 0 ];
+			return this.imagesInQueue[ 0 ];
+		},
+
+		/**
+		 * Pending state is queue-specific
+		 * @return {bool}
+		 */
+		isPending: function () {
+			return this.pending[ this.queue ];
 		}
-	} )
+	} ),
+
+	methods: $.extend( {}, mapActions( [
+		'getImages'
+	] ) ),
+
+	watch: {
+		/**
+		 * If a queue reaches zero images, attempt to fetch more
+		 *
+		 * @param {Array} oldVal
+		 * @param {Array} newVal
+		 */
+		imagesInQueue: function ( oldVal, newVal ) {
+			if ( newVal.length === 0 ) {
+				this.getImages( {
+					queue: this.currentTab
+				} );
+			}
+		}
+	}
 };
 </script>

--- a/resources/components/ImageCard.vue
+++ b/resources/components/ImageCard.vue
@@ -46,7 +46,8 @@
 </template>
 
 <script>
-var Button = require( './base/Button.vue' ),
+var mapActions = require( 'vuex' ).mapActions,
+	Button = require( './base/Button.vue' ),
 	Suggestion = require( './base/Suggestion.vue' );
 
 // @vue/component
@@ -75,18 +76,30 @@ module.exports = {
 	},
 
 	computed: {
+		/**
+		 * @return {string}
+		 */
 		title: function () {
 			return this.image.title;
 		},
 
+		/**
+		 * @return {string}
+		 */
 		thumbUrl: function () {
 			return this.image.thumburl;
 		},
 
+		/**
+		 * @return {string}
+		 */
 		descriptionUrl: function () {
 			return this.image.descriptionurl;
 		},
 
+		/**
+		 * @return {Array} Array of suggestion objects
+		 */
 		confirmedSuggestions: function () {
 			return this.suggestions.filter( function ( suggestion ) {
 				return suggestion.confirmed;
@@ -94,17 +107,42 @@ module.exports = {
 		}
 	},
 
-	methods: {
+	methods: $.extend( {}, mapActions( [
+		'getImages',
+		'skipImage'
+	] ), {
+		/**
+		 * Mutate the suggestion state in-place
+		 *
+		 * @param {Object} suggestion
+		 */
 		toggleConfirmed: function ( suggestion ) {
 			suggestion.confirmed = !suggestion.confirmed;
 		},
+
+		/**
+		 * @TODO implement me
+		 */
 		onPublish: function () {
-			// eslint-disable-next-line no-console
-			console.log( 'On publish' );
+			this.skipImage();
 		},
+
+		/**
+		 * @TODO implement me
+		 */
 		onSkip: function () {
-			// eslint-disable-next-line no-console
-			console.log( 'On skip' );
+			this.skipImage();
+		}
+	} ),
+
+	watch: {
+		/**
+		 * Watch the image props. If props change because the queue has shifted,
+		 * force-reset the suggestions state to the suggestions associated with
+		 * the new image.
+		 */
+		image: function () {
+			this.suggestions = this.image.suggestions;
 		}
 	}
 };

--- a/resources/components/base/Message.vue
+++ b/resources/components/base/Message.vue
@@ -51,10 +51,10 @@ module.exports = {
 			return classes;
 		},
 		icon: function () {
-			return ICON_MAP[ this.type ]
+			return ICON_MAP[ this.type ];
 		},
 		iconClass: function () {
-			return 'oo-ui-image-' + this.type
+			return 'oo-ui-image-' + this.type;
 		}
 	}
 };

--- a/resources/components/base/Suggestion.vue
+++ b/resources/components/base/Suggestion.vue
@@ -45,7 +45,7 @@ module.exports = {
 	},
 
 	computed: {
-		classObject() {
+		classObject: function () {
 			return {
 				'mw-suggestion--confirmed': this.confirmed
 			};

--- a/tests/jest/App.test.js
+++ b/tests/jest/App.test.js
@@ -1,6 +1,7 @@
 const VueTestUtils = require( '@vue/test-utils' );
 const Vuex = require( 'vuex' );
 const App = require( '../../resources/components/App.vue' );
+const Tabs = require( '../../resources/components/base/Tabs.vue' );
 const i18n = require( '../../../../resources/src/vue/i18n.js' );
 
 const localVue = VueTestUtils.createLocalVue();
@@ -8,38 +9,98 @@ localVue.use( i18n );
 localVue.use( Vuex );
 
 describe( 'App', () => {
-	let actions,
+	let state,
 		getters,
+		actions,
 		store;
 
 	// Mock Vuex store for testing
 	beforeEach( () => {
+		state = {
+			currentTab: 'A',
+			images: {
+				A: [],
+				B: []
+			},
+
+			pending: {
+				A: false,
+				B: false
+			}
+		};
+
 		getters = {
-			showTabs: jest.fn()
+			isAuthenticated: jest.fn(),
+			isAutoconfirmed: jest.fn(),
+			tabs: function () {
+				return Object.keys( state.images );
+			}
 		};
 
 		actions = {
-			getImages: jest.fn()
+			getImages: jest.fn(),
+			updateCurrentTab: jest.fn()
 		};
 
 		store = new Vuex.Store( {
-			state: {
-				currentTab: 'A'
-			},
+			state,
 			getters,
 			actions
 		} );
 	} );
 
-	it( 'displays tabs if "showTabs" is true', () => {
-		getters.showTabs.mockReturnValue( true );
+	it( 'does not display if user is not logged in', () => {
+		getters.isAuthenticated.mockReturnValue( false );
+		getters.isAutoconfirmed.mockReturnValue( false );
+
+		const wrapper = VueTestUtils.shallowMount( App, { store, localVue } );
+		expect( wrapper.contains( '.wbmad-suggested-tags-page-tabs-heading' ) ).toBe( false );
+	} );
+
+	it( 'does not display if user is not autoconfirmed', () => {
+		getters.isAuthenticated.mockReturnValue( true );
+		getters.isAutoconfirmed.mockReturnValue( false );
+
+		const wrapper = VueTestUtils.shallowMount( App, { store, localVue } );
+		expect( wrapper.contains( '.wbmad-suggested-tags-page-tabs-heading' ) ).toBe( false );
+	} );
+
+	it( 'displays if user is both authenticated and autoconfirmed', () => {
+		getters.isAuthenticated.mockReturnValue( true );
+		getters.isAutoconfirmed.mockReturnValue( true );
+
 		const wrapper = VueTestUtils.shallowMount( App, { store, localVue } );
 		expect( wrapper.contains( '.wbmad-suggested-tags-page-tabs-heading' ) ).toBe( true );
 	} );
 
-	it( 'does not display tabs if "showTabs" is false', () => {
-		getters.showTabs.mockReturnValue( false );
-		const wrapper = VueTestUtils.shallowMount( App, { store, localVue } );
-		expect( wrapper.contains( '.wbmad-suggested-tags-page-tabs-heading' ) ).toBe( false );
+	it( 'dispatches the updateCurrentTab action when the tab is changed', () => {
+		getters.isAuthenticated.mockReturnValue( true );
+		getters.isAutoconfirmed.mockReturnValue( true );
+
+		// Use mount so we can trigger event from the child Tab component,
+		// but stub the ImageCard because we don't care about it here
+		const wrapper = VueTestUtils.mount( App, {
+			store,
+			localVue,
+			stubs: [ 'wbmad-image-card' ]
+		} );
+
+		wrapper.find( Tabs ).vm.$emit( 'tab-change', { title: 'B' } );
+
+		// Expect the updateCurrentTab action to be dispatched
+		expect( actions.updateCurrentTab.mock.calls.length ).toBe( 1 );
+
+		// Expect the call to updateCurrentTab to contain the correct payload
+		expect( actions.updateCurrentTab.mock.calls[ 0 ][ 1 ] ).toBe( 'b' );
+	} );
+
+	it( 'dispatches a getImages action for user images when mounted', () => {
+		getters.isAuthenticated.mockReturnValue( true );
+		getters.isAutoconfirmed.mockReturnValue( true );
+
+		// Expect the getImages action to be dispatched when component is mounted
+		expect( actions.getImages.mock.calls.length ).toBe( 0 );
+		VueTestUtils.shallowMount( App, { store, localVue } );
+		expect( actions.getImages.mock.calls.length ).toBe( 1 );
 	} );
 } );


### PR DESCRIPTION
Being able to keep track of both "popular" and "user" queues simultaneously
should improve the perceived performance of this app from the user's
perspective. Previously, the current queue data was discarded each time the
user switched to a new tab, which meant waiting for new data from the API.

This change refactors the Vuex store to make certain properties (image array,
pending state) queue-dependent. Similarly, some of the mutations and actions
have been updated to become "queue-aware", typically defaulting to the current
active tab if a queue parameter is not provided.

Components have been updated to handle the new Vuex structure.

A few other changes that also made it in include:

* isAuthenticated and isAutoconfirmed have been pulled out of state and into
  getters, since they are technically returning derivative attributes
* attempted to consistently use $.extend with Vuex helpers; the format here is:
  $.extend( {}, mapWhatever( [] ), { localMethodOrProperty: function () {} } )
* Uses a watcher to ensure that fresh suggestions are copied into the ImageCard
  component's state the moment that its `image` prop changes
* Added method/computed property documentation
* Fleshed out the App.vue unit test

Change-Id: If58cc1e63fa62285a0a5a994903b98228aeb5df0