### PR TITLE
Add toast notification base component

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -233,6 +233,7 @@
 				"components/base/Suggestion.vue",
 				"components/base/Tabs.vue",
 				"components/base/Tab.vue",
+				"components/base/ToastNotification.vue",
 				"plugins/api.js",
 				"store/index.js",
 				"models/ImageData.js",

--- a/extension.json
+++ b/extension.json
@@ -305,6 +305,10 @@
 			],
 			"dependencies": [
 				"vue"
+			],
+			"targets": [
+				"desktop",
+				"mobile"
 			]
 		}
 	},

--- a/extension.json
+++ b/extension.json
@@ -306,6 +306,10 @@
 			],
 			"dependencies": [
 				"vue"
+			],
+			"targets": [
+				"desktop",
+				"mobile"
 			]
 		}
 	},

--- a/resources/components/App.vue
+++ b/resources/components/App.vue
@@ -1,10 +1,22 @@
 <template>
 	<div class="wbmad-suggested-tags-page">
-		<toast-notification v-if="error" type="error">
+		<toast-notification
+			v-if="publishError"
+			v-bind:key="'publishError-' + Date.now()"
+			type="error"
+			duration="8"
+			v-on:leave="onToastLeave"
+		>
 			<p v-i18n-html:machinevision-publish-error-message />
 		</toast-notification>
 
-		<toast-notification v-if="success" type="success">
+		<toast-notification
+			v-if="publishSuccess"
+			v-bind:key="'publishSuccess-' + Date.now()"
+			type="success"
+			duration="4"
+			v-on:leave="onToastLeave"
+		>
 			<p v-i18n-html:machinevision-success-message />
 		</toast-notification>
 
@@ -86,8 +98,7 @@ module.exports = {
 	},
 
 	computed: $.extend( {}, mapState( [
-		'success',
-		'error'
+		'publishState'
 	] ), mapGetters( [
 		'tabs',
 		'isAuthenticated',
@@ -111,12 +122,21 @@ module.exports = {
 		 */
 		loginMessage: function () {
 			return mw.config.get( 'wgMVSuggestedTagsLoginMessage' );
+		},
+
+		publishSuccess: function () {
+			return this.publishState === 'success';
+		},
+
+		publishError: function () {
+			return this.publishState === 'error';
 		}
 	} ),
 
 	methods: $.extend( {}, mapActions( [
 		'updateCurrentTab',
-		'getImages'
+		'getImages',
+		'updatePublishState'
 	] ), {
 		/**
 		 * Watch the tab change events emitted by the <Tabs> component
@@ -126,6 +146,10 @@ module.exports = {
 		 */
 		onTabChange: function ( tab ) {
 			this.updateCurrentTab( tab.title.toLowerCase() );
+		},
+
+		onToastLeave: function () {
+			this.updatePublishState( null );
 		}
 	} ),
 

--- a/resources/components/App.vue
+++ b/resources/components/App.vue
@@ -1,14 +1,12 @@
 <template>
 	<div class="wbmad-suggested-tags-page">
-		<!-- Error message box: convert to component -->
-		<div v-if="error" class="wbmad-toast wbmad-publish-error-toast">
+		<toast-notification v-if="error" type="error">
 			<p v-i18n-html:machinevision-publish-error-message />
-		</div>
+		</toast-notification>
 
-		<!-- Success message box: convert to component -->
-		<div v-if="success" class="wbmad-toast wbmad-success-toast">
+		<toast-notification v-if="success" type="success">
 			<p v-i18n-html:machinevision-success-message />
-		</div>
+		</toast-notification>
 
 		<!-- Tabs container -->
 		<template v-if="showTabs">
@@ -24,6 +22,9 @@
 					<card-stack v-bind:queue="tab" />
 				</tab>
 			</tabs>
+
+			<div v-i18n-html:machinevision-machineaidedtagging-license-information
+				class="wbmad-suggested-tags-page-license-info" />
 		</template>
 
 		<!-- Login message container -->
@@ -70,6 +71,7 @@ var mapState = require( 'vuex' ).mapState,
 	mapActions = require( 'vuex' ).mapActions,
 	Tabs = require( './base/Tabs.vue' ),
 	Tab = require( './base/Tab.vue' ),
+	ToastNotification = require( './base/ToastNotification.vue' ),
 	CardStack = require( './CardStack.vue' );
 
 // @vue/component
@@ -79,6 +81,7 @@ module.exports = {
 	components: {
 		tabs: Tabs,
 		tab: Tab,
+		'toast-notification': ToastNotification,
 		'card-stack': CardStack
 	},
 
@@ -143,19 +146,6 @@ module.exports = {
 
 .wbmad-suggested-tags-page {
 	max-width: @wbmad-max-width;
-
-	// Necessary to center fixed toast messages within page element on desktop.
-	@media screen and ( min-width: @width-breakpoint-tablet ) {
-		.flex-display();
-		flex-wrap: wrap;
-		justify-content: center;
-	}
-
-	.wbmad-suggested-tags-page-tabs-heading,
-	.wbmad-suggested-tags-page-tabs,
-	.wbmad-suggested-tags-page-license-info {
-		width: 100%;
-	}
 
 	.wbmad-suggested-tags-page-tabs-heading {
 		border: 0;

--- a/resources/components/App.vue
+++ b/resources/components/App.vue
@@ -98,7 +98,7 @@ module.exports = {
 	},
 
 	computed: $.extend( {}, mapState( [
-		'publishState'
+		'publishStatus'
 	] ), mapGetters( [
 		'tabs',
 		'isAuthenticated',
@@ -125,18 +125,18 @@ module.exports = {
 		},
 
 		publishSuccess: function () {
-			return this.publishState === 'success';
+			return this.publishStatus === 'success';
 		},
 
 		publishError: function () {
-			return this.publishState === 'error';
+			return this.publishStatus === 'error';
 		}
 	} ),
 
 	methods: $.extend( {}, mapActions( [
 		'updateCurrentTab',
 		'getImages',
-		'updatePublishState'
+		'updatePublishStatus'
 	] ), {
 		/**
 		 * Watch the tab change events emitted by the <Tabs> component
@@ -149,7 +149,7 @@ module.exports = {
 		},
 
 		onToastLeave: function () {
-			this.updatePublishState( null );
+			this.updatePublishStatus( null );
 		}
 	} ),
 

--- a/resources/components/ImageCard.vue
+++ b/resources/components/ImageCard.vue
@@ -108,7 +108,7 @@ module.exports = {
 	},
 
 	methods: $.extend( {}, mapActions( [
-		'getImages',
+		'publishTags',
 		'skipImage'
 	] ), {
 		/**
@@ -124,7 +124,7 @@ module.exports = {
 		 * @TODO implement me
 		 */
 		onPublish: function () {
-			this.skipImage();
+			this.publishTags();
 		},
 
 		/**

--- a/resources/components/base/ToastNotification.vue
+++ b/resources/components/base/ToastNotification.vue
@@ -1,0 +1,130 @@
+<template>
+	<div v-if="showWrapper" class="mw-toast">
+		<transition
+			appear
+			name="mw-toast"
+			appear-class="mw-toast-appear"
+			appear-active-class="mw-toast-appear-active"
+			appear-to-class="mw-toast-appear-to"
+			v-on:appear="onAppear"
+			v-on:after-leave="afterLeave"
+		>
+			<div
+				v-if="show"
+				class="mw-toast__notification"
+				v-bind:aria-live="type !== 'error' ? 'polite' : false"
+				v-bind:role="type === 'error' ? 'alert' : false "
+			>
+				<div class="mw-toast__notification__content">
+					<slot />
+				</div>
+			</div>
+		</transition>
+	</div>
+</template>
+
+<script>
+/**
+ * A small pop-up notification.
+ *
+ * When specifying duration, ensure the user will have sufficient time to read
+ * and process the notification. Message content should be as concise as
+ * possible.
+ *
+ * Specifitying notification type provides helpful information to screen readers.
+ * Type can be one of "success" or "error".
+ */
+// @vue/component
+module.exports = {
+	name: 'ToastNotification',
+
+	props: {
+		type: {
+			type: String,
+			default: 'notice'
+		},
+		duration: {
+			type: Number, // in seconds
+			default: 10
+		}
+	},
+
+	data: function () {
+		return {
+			show: true,
+			showWrapper: true
+		};
+	},
+
+	methods: {
+		/**
+		 * When this component appears, start a countdown based on the provided
+		 * duration, then hide the toast, which kicks off leave transitions.
+		 */
+		onAppear: function () {
+			var self = this;
+			setTimeout( function () {
+				self.show = false;
+			}, this.duration * 1000 );
+		},
+		/**
+		 * After the leave transitions finish, remove the toast and wrapper.
+		 */
+		afterLeave: function () {
+			this.showWrapper = false;
+		}
+	}
+};
+</script>
+
+<style lang="less">
+@import 'mediawiki.mixins';
+@import '../../style-variables.less';
+
+.mw-toast {
+	// Center the toast within the parent container.
+	.flex-display();
+	justify-content: center;
+}
+
+.mw-toast__notification {
+	background-color: @base10;
+	border-radius: @outer-border-radius;
+	bottom: 5vh;
+	color: @base100;
+	display: inline-block;
+	margin: 0;
+	padding: 8px 32px;
+	position: fixed;
+	text-align: center;
+	width: 95%;
+
+	@media screen and ( min-width: @width-breakpoint-tablet ) {
+		width: auto;
+	}
+}
+
+.mw-toast__notification__content {
+	// In case slot content isn't wrapped in a paragraph tag, let's duplicate
+	// the margins here (they'll collapse if a p tag is used).
+	margin: 0.5em 0;
+}
+
+// Transitions.
+.mw-toast-appear,
+.mw-toast-leave-to {
+	bottom: 0;
+	opacity: 0;
+}
+
+.mw-toast-appear-active,
+.mw-toast-leave-active {
+	transition: bottom 1s, opacity 1s;
+}
+
+.mw-toast-appear-to {
+	bottom: 5vh;
+	opacity: 1;
+}
+
+</style>

--- a/resources/components/base/ToastNotification.vue
+++ b/resources/components/base/ToastNotification.vue
@@ -72,6 +72,10 @@ module.exports = {
 		 */
 		afterLeave: function () {
 			this.showWrapper = false;
+
+			// Emit an event that can be used by the parent to act (e.g. change
+			// state) once the toast has been removed.
+			this.$emit( 'leave', this.$vnode.key );
 		}
 	}
 };

--- a/resources/store/index.js
+++ b/resources/store/index.js
@@ -86,7 +86,7 @@ module.exports = new Vuex.Store( {
 			user: false
 		},
 
-		publishState: null
+		publishStatus: null
 
 	},
 
@@ -195,8 +195,14 @@ module.exports = new Vuex.Store( {
 			state.pending = true;
 		},
 
-		setPublishState: function ( state, publishState ) {
-			state.publishState = publishState;
+		/**
+		 * Set the publish status (to success, error, or null).
+		 *
+		 * @param {Object} state
+		 * @param {string|null} publishStatus
+		 */
+		setPublishStatus: function ( state, publishStatus ) {
+			state.publishStatus = publishStatus;
 		}
 	},
 
@@ -315,8 +321,8 @@ module.exports = new Vuex.Store( {
 			context.dispatch( 'skipImage' );
 
 			// Clear out any existing publish notifications.
-			context.dispatch( 'updatePublishState', null );
-			context.dispatch( 'updatePublishState', 'success' );
+			context.dispatch( 'updatePublishStatus', null );
+			context.dispatch( 'updatePublishStatus', 'success' );
 
 			// TODO: handle error.
 		},
@@ -335,13 +341,13 @@ module.exports = new Vuex.Store( {
 		},
 
 		/**
-		 * Set the publish state to show or clear notifications.
+		 * Set the publish status to show or clear notifications.
 		 *
 		 * @param {Object} context
-		 * @param {string} publishState
+		 * @param {string} publishStatus
 		 */
-		updatePublishState: function ( context, publishState ) {
-			context.commit( 'setPublishState', publishState );
+		updatepublishStatus: function ( context, publishStatus ) {
+			context.commit( 'setPublishStatus', publishStatus );
 		}
 	}
 } );

--- a/resources/store/index.js
+++ b/resources/store/index.js
@@ -86,9 +86,7 @@ module.exports = new Vuex.Store( {
 			user: false
 		},
 
-		error: false,
-
-		success: false
+		publishState: null
 
 	},
 
@@ -195,6 +193,10 @@ module.exports = new Vuex.Store( {
 		clearImages: function ( state ) {
 			state.images[ state.currentTab ] = [];
 			state.pending = true;
+		},
+
+		setPublishState: function ( state, publishState ) {
+			state.publishState = publishState;
 		}
 	},
 
@@ -306,9 +308,17 @@ module.exports = new Vuex.Store( {
 		 * we are running low on data
 		 *
 		 * @param {Object} context
-		 * @param {Object} payload
 		 */
-		publishTags: function ( /* context, payload */ ) {
+		publishTags: function ( context ) {
+			// TODO: Handle publish.
+
+			context.dispatch( 'skipImage' );
+
+			// Clear out any existing publish notifications.
+			context.dispatch( 'updatePublishState', null );
+			context.dispatch( 'updatePublishState', 'success' );
+
+			// TODO: handle error.
 		},
 
 		/**
@@ -321,6 +331,17 @@ module.exports = new Vuex.Store( {
 		 */
 		skipImage: function ( context ) {
 			context.commit( 'removeImage' );
+
+		},
+
+		/**
+		 * Set the publish state to show or clear notifications.
+		 *
+		 * @param {Object} context
+		 * @param {string} publishState
+		 */
+		updatePublishState: function ( context, publishState ) {
+			context.commit( 'setPublishState', publishState );
 		}
 	}
 } );

--- a/tests/jest/App.test.js
+++ b/tests/jest/App.test.js
@@ -2,7 +2,7 @@ const VueTestUtils = require( '@vue/test-utils' );
 const Vuex = require( 'vuex' );
 const App = require( '../../resources/components/App.vue' );
 const Tabs = require( '../../resources/components/base/Tabs.vue' );
-const i18n = require( '../../../../resources/src/vue/i18n.js' );
+const i18n = require( './plugins/i18n' );
 
 const localVue = VueTestUtils.createLocalVue();
 localVue.use( i18n );

--- a/tests/jest/plugins/i18n.js
+++ b/tests/jest/plugins/i18n.js
@@ -1,0 +1,58 @@
+/*!
+ * i18n plugin for Vue that connects to MediaWiki's i18n system.
+ *
+ * Based on https://github.com/santhoshtr/vue-banana-i18n , but modified to connect to mw.message()
+ * instead of banana-i18n.
+ */
+
+module.exports = {
+	install: function ( Vue ) {
+		/**
+		 * @class Vue
+		 */
+
+		/**
+		 * Adds an `$i18n()` instance method that can be used in all components. This method is a
+		 * proxy to mw.message.
+		 *
+		 * Usage:
+		 *     `<p>{{ $i18n( 'my-message-keys', param1, param2 ) }}</p>`
+		 *     or
+		 *     `<p>{{ $i18n( 'my-message-keys' ).params( [ param1, param2 ] ) }}</p>`
+		 *
+		 * Note that this method only works for messages that return text. For messages that
+		 * need to be parsed to HTML, use the v-i18n-html directive.
+		 *
+		 * @param {string} key Key of message to get
+		 * @param {...Mixed} parameters Values for $N replacements
+		 * @return {mw.Message}
+		 */
+		Vue.prototype.$i18n = function () {
+			return mw.message.apply( mw, arguments );
+		};
+
+		/*
+		 * Add a custom v-i18n-html directive. This is used to inject parsed i18n message contents.
+		 *
+		 * <div v-i18n-html:my-message-key></div>
+		 *     Parses the my-message-key message and injects the parsed HTML into the div.
+		 *     Equivalent to v-html="mw.message( 'my-message-key' ).parse()"
+		 *
+		 * <div v-i18n-html="msgKey"></div>
+		 *     Looks in the msgKey variable for the message name, and parses that message.
+		 *     Equivalent to v-html="mw.message( msgKey ).parse()"
+		 *
+		 * <div v-i18n-html="'my-message-key'"></div>
+		 *     Parses the message named my-message-key. Note the nested quotes!
+		 *     Equivalent to v-html="mw.message( 'my-message-key' ).parse()"
+		 */
+		Vue.directive( 'i18n-html', {
+			bind: function ( el, binding ) {
+				// If v-i18n-html:foo was used, binding.arg = 'foo'
+				// If v-i18n-html="'foo'" was used, binding.value = 'foo'
+				var messageKey = binding.arg || binding.value;
+				el.innerHTML = mw.message( messageKey ).parse();
+			}
+		} );
+	}
+};


### PR DESCRIPTION
I made some adjustments to the existing toast component:
- Renamed it "toast notification" because "toast" can be confusing
- Adjusted the styles so that it's completely independent of the parent component. The toast should be centered within the parent container without needing to add styles to the parent.
- Instead of having to write a CSS rule per-toast to specify animation duration, you can just pass in a duration prop

Basically, Vue made this whole thing much simpler and more flexible. Yay!