### PR TITLE
Add local copy of i18n plugin to enable unit tests in CI

### DIFF
--- a/tests/jest/App.test.js
+++ b/tests/jest/App.test.js
@@ -2,7 +2,7 @@ const VueTestUtils = require( '@vue/test-utils' );
 const Vuex = require( 'vuex' );
 const App = require( '../../resources/components/App.vue' );
 const Tabs = require( '../../resources/components/base/Tabs.vue' );
-const i18n = require( '../../../../resources/src/vue/i18n.js' );
+const i18n = require( './plugins/i18n' );
 
 const localVue = VueTestUtils.createLocalVue();
 localVue.use( i18n );

--- a/tests/jest/plugins/i18n.js
+++ b/tests/jest/plugins/i18n.js
@@ -1,0 +1,58 @@
+/*!
+ * i18n plugin for Vue that connects to MediaWiki's i18n system.
+ *
+ * Based on https://github.com/santhoshtr/vue-banana-i18n , but modified to connect to mw.message()
+ * instead of banana-i18n.
+ */
+
+module.exports = {
+	install: function ( Vue ) {
+		/**
+		 * @class Vue
+		 */
+
+		/**
+		 * Adds an `$i18n()` instance method that can be used in all components. This method is a
+		 * proxy to mw.message.
+		 *
+		 * Usage:
+		 *     `<p>{{ $i18n( 'my-message-keys', param1, param2 ) }}</p>`
+		 *     or
+		 *     `<p>{{ $i18n( 'my-message-keys' ).params( [ param1, param2 ] ) }}</p>`
+		 *
+		 * Note that this method only works for messages that return text. For messages that
+		 * need to be parsed to HTML, use the v-i18n-html directive.
+		 *
+		 * @param {string} key Key of message to get
+		 * @param {...Mixed} parameters Values for $N replacements
+		 * @return {mw.Message}
+		 */
+		Vue.prototype.$i18n = function () {
+			return mw.message.apply( mw, arguments );
+		};
+
+		/*
+		 * Add a custom v-i18n-html directive. This is used to inject parsed i18n message contents.
+		 *
+		 * <div v-i18n-html:my-message-key></div>
+		 *     Parses the my-message-key message and injects the parsed HTML into the div.
+		 *     Equivalent to v-html="mw.message( 'my-message-key' ).parse()"
+		 *
+		 * <div v-i18n-html="msgKey"></div>
+		 *     Looks in the msgKey variable for the message name, and parses that message.
+		 *     Equivalent to v-html="mw.message( msgKey ).parse()"
+		 *
+		 * <div v-i18n-html="'my-message-key'"></div>
+		 *     Parses the message named my-message-key. Note the nested quotes!
+		 *     Equivalent to v-html="mw.message( 'my-message-key' ).parse()"
+		 */
+		Vue.directive( 'i18n-html', {
+			bind: function ( el, binding ) {
+				// If v-i18n-html:foo was used, binding.arg = 'foo'
+				// If v-i18n-html="'foo'" was used, binding.value = 'foo'
+				var messageKey = binding.arg || binding.value;
+				el.innerHTML = mw.message( messageKey ).parse();
+			}
+		} );
+	}
+};


### PR DESCRIPTION
Until MediaWiki's i18n vue plugin is exposed as a node module, there is not a
great way to use this plugin when running unit tests in Jest. Previously we
have been reaching back up into the parent Mediawiki directory to find the file,
but this isn't possible when running JS unit tests in a stand-alone CI
environment. In order to allow for this, I've take the step to copy the plugin
code into our test folder for now. This can be removed once there is a better
way to consume this plugin outside of Mediawiki.

Change-Id: I0caf4dea7cc1fb879d887deb9e351e5e6280be28