### PR TITLE
Refactor components to use Vuex for image & suggestion data

### DIFF
--- a/resources/components/CardStack.vue
+++ b/resources/components/CardStack.vue
@@ -2,8 +2,8 @@
 	<div class="wbmad-suggested-tags-cardstack">
 		<wbmad-cardstack-placeholder v-if="isPending" />
 
-		<template v-else-if="currentImage">
-			<wbmad-image-card v-bind:image="currentImage" />
+		<template v-else-if="shouldDisplayImage">
+			<wbmad-image-card />
 		</template>
 
 		<!-- TODO: Handle no images (cases: error; finished tagging user images). -->
@@ -15,6 +15,7 @@
 
 <script>
 var mapState = require( 'vuex' ).mapState,
+	mapGetters = require( 'vuex' ).mapGetters,
 	mapActions = require( 'vuex' ).mapActions,
 	CardStackPlaceholder = require( './CardStackPlaceholder.vue' ),
 	ImageCard = require( './ImageCard.vue' );
@@ -39,6 +40,8 @@ module.exports = {
 		'currentTab',
 		'pending',
 		'images'
+	] ), mapGetters( [
+		'currentImage'
 	] ), {
 		/**
 		 * @return {Array}
@@ -48,18 +51,22 @@ module.exports = {
 		},
 
 		/**
-		 * @return {Object|undefined}
-		 */
-		currentImage: function () {
-			return this.imagesInQueue[ 0 ];
-		},
-
-		/**
 		 * Pending state is queue-specific
 		 * @return {bool}
 		 */
 		isPending: function () {
 			return this.pending[ this.queue ];
+		},
+
+		/**
+		 * Whether to render the ImageCard.
+		 * We need a dedicated computed property for this because
+		 * ResourceLoader can't handle "&&" in the template.
+		 *
+		 * @return {boolean}
+		 */
+		shouldDisplayImage: function () {
+			return this.currentImage && this.imagesInQueue;
 		}
 	} ),
 

--- a/resources/store/index.js
+++ b/resources/store/index.js
@@ -151,7 +151,10 @@ module.exports = new Vuex.Store( {
 		 */
 		currentImageSuggestions: function ( state, getters ) {
 			if ( getters.currentImage ) {
-				return getters.currentImage.suggestions;
+				// Filter out suggestions with no label.
+				return getters.currentImage.suggestions.filter( function ( suggestion ) {
+					return suggestion.text;
+				} );
 			} else {
 				return [];
 			}

--- a/resources/store/index.js
+++ b/resources/store/index.js
@@ -145,6 +145,19 @@ module.exports = new Vuex.Store( {
 		},
 
 		/**
+		 * @param {Object} state
+		 * @param {Object} getters
+		 * @return {Array} suggestions
+		 */
+		currentImageSuggestions: function ( state, getters ) {
+			if ( getters.currentImage ) {
+				return getters.currentImage.suggestions;
+			} else {
+				return [];
+			}
+		},
+
+		/**
 		 * Whether or not the user is logged in. Derived from non-Vuex global
 		 * state.
 		 *
@@ -235,6 +248,19 @@ module.exports = new Vuex.Store( {
 		clearImages: function ( state ) {
 			state.images[ state.currentTab ] = [];
 			state.pending = true;
+		},
+
+		/**
+		 * Toggle the confirmation state of a single suggestion of an image
+		 *
+		 * @param {Object} state
+		 * @param {integer} index
+		 */
+		toggleSuggestion: function ( state, index ) {
+			var currentImage = state.images[ state.currentTab ][ 0 ],
+				selected = currentImage.suggestions[ index ];
+
+			selected.confirmed = !selected.confirmed;
 		},
 
 		/**
@@ -349,6 +375,22 @@ module.exports = new Vuex.Store( {
 		},
 
 		/**
+		 * Find a given tag among the current image suggestions and commit the
+		 * toggleSuggestion mutation to flip its state. Do nothing if tag is
+		 * not found.
+		 *
+		 * @param {Object} context
+		 * @param {Object} tag
+		 */
+		toggleTagConfirmation: function ( context, tag ) {
+			var tagIndex = context.getters.currentImageSuggestions.indexOf( tag );
+
+			if ( tagIndex >= 0 ) {
+				context.commit( 'toggleSuggestion', tagIndex );
+			}
+		},
+
+		/**
 		 * @TODO implement this
 		 *
 		 * submits user selections for current image to API and commits the
@@ -356,10 +398,10 @@ module.exports = new Vuex.Store( {
 		 * we are running low on data
 		 *
 		 * @param {Object} context
-		 * @param {Array} tags
 		 */
-		publishTags: function ( context, tags ) {
-			var reviewBatch = tags.map( function ( tag ) {
+		publishTags: function ( context ) {
+			var tags = context.getters.currentImageSuggestions,
+				reviewBatch = tags.map( function ( tag ) {
 					return {
 						label: tag.wikidataId,
 						review: tag.confirmed ? 'accept' : 'reject'

--- a/tests/jest/App.test.js
+++ b/tests/jest/App.test.js
@@ -32,7 +32,8 @@ describe( 'App', () => {
 
 		getters = {
 			isAuthenticated: jest.fn(),
-			isAutoconfirmed: jest.fn()
+			isAutoconfirmed: jest.fn(),
+			currentImage: jest.fn() // needed for tests that use deep mounting
 		};
 
 		actions = {

--- a/tests/jest/CardStack.test.js
+++ b/tests/jest/CardStack.test.js
@@ -3,7 +3,6 @@ const VueTestUtils = require( '@vue/test-utils' );
 const Vuex = require( 'vuex' );
 const CardStack = require( '../../resources/components/CardStack.vue' );
 const ImageCard = require( '../../resources/components/ImageCard.vue' );
-const Suggestion = require( '../../resources/components/base/Suggestion.vue' );
 const i18n = require( './plugins/i18n' );
 const imageData = require( './fixtures/imageData.json' );
 
@@ -14,6 +13,7 @@ localVue.use( Vuex );
 describe( 'CardStack', () => {
 	let state,
 		mutations,
+		getters,
 		actions,
 		store;
 
@@ -36,6 +36,10 @@ describe( 'CardStack', () => {
 			}
 		};
 
+		getters = {
+			currentImage: jest.fn()
+		};
+
 		actions = {
 			getImages: jest.fn()
 		};
@@ -43,21 +47,9 @@ describe( 'CardStack', () => {
 		store = new Vuex.Store( {
 			state,
 			mutations,
+			getters,
 			actions
 		} );
-	} );
-
-	it( 'passes the first image in the appropriate Vuex queue to ImageCard as props', () => {
-		const wrapper = VueTestUtils.mount( CardStack, {
-			propsData: {
-				queue: 'popular'
-			},
-			store,
-			localVue
-		} );
-
-		let imageCard = wrapper.find( ImageCard );
-		expect( imageCard.vm.image ).toMatchObject( wrapper.vm.currentImage );
 	} );
 
 	it( 'does not render the ImageCard component when there are no images in the queue', () => {
@@ -72,8 +64,10 @@ describe( 'CardStack', () => {
 		expect( wrapper.contains( ImageCard ) ).toBe( false );
 	} );
 
-	it( 'Clicking a suggestion inside ImageCard does not change the data inside Cardstack', () => {
-		const wrapper = VueTestUtils.mount( CardStack, {
+	it( 'renders the ImageCard component when there are images in the queue', () => {
+		getters.currentImage.mockReturnValue( imageData[ 0 ] );
+
+		const wrapper = VueTestUtils.shallowMount( CardStack, {
 			propsData: {
 				queue: 'popular'
 			},
@@ -81,17 +75,7 @@ describe( 'CardStack', () => {
 			localVue
 		} );
 
-		let imageCard = wrapper.find( ImageCard );
-		let suggestion = wrapper.find( Suggestion );
-
-		let suggestionInParent = wrapper.vm.currentImage.suggestions[ 0 ];
-		let suggestionInChild = imageCard.vm.suggestions[ 0 ];
-
-		expect( suggestionInParent.confirmed ).toBe( false );
-		expect( suggestionInChild.confirmed ).toBe( false );
-		suggestion.trigger( 'click' );
-		expect( suggestionInParent.confirmed ).toBe( false );
-		expect( suggestionInChild.confirmed ).toBe( true );
+		expect( wrapper.contains( ImageCard ) ).toBe( true );
 	} );
 
 	it( 'dispatches the getImages action when the count of the image queue reaches zero', done => {

--- a/tests/jest/ImageCard.test.js
+++ b/tests/jest/ImageCard.test.js
@@ -1,4 +1,3 @@
-const Vue = require( 'vue' );
 const VueTestUtils = require( '@vue/test-utils' );
 const Vuex = require( 'vuex' );
 const ImageCard = require( '../../resources/components/ImageCard.vue' );
@@ -10,86 +9,96 @@ localVue.use( i18n );
 localVue.use( Vuex );
 
 describe( 'ImageCard', () => {
-	let actions,
+	let state,
+		getters,
+		actions,
 		store;
 
 	beforeEach( () => {
+		state = {
+			images: {
+				popular: imageFixtures,
+				user: []
+			}
+		};
+
+		getters = {
+			currentImage: jest.fn(),
+			currentImageSuggestions: jest.fn()
+		};
+
 		actions = {
 			publishTags: jest.fn(),
 			skipImage: jest.fn()
 		};
 
 		store = new Vuex.Store( {
-			state: {},
+			state,
+			getters,
 			actions
 		} );
 	} );
 
-	it( 'makes a deep copy of suggestions data received from props', () => {
-		const wrapper = VueTestUtils.mount( ImageCard, {
-			propsData: {
-				image: imageFixtures[ 0 ]
-			},
-			store,
-			localVue
-		} );
-
-		let propsSuggestion = imageFixtures[ 0 ].suggestions[ 0 ];
-		let localSuggestion = wrapper.vm.suggestions[ 0 ];
-
-		expect( localSuggestion ).toEqual( propsSuggestion );
-		expect( localSuggestion ).not.toBe( propsSuggestion );
-	} );
-
 	it( 'publish button is disabled when no suggestions are confirmed', () => {
-		const wrapper = VueTestUtils.mount( ImageCard, {
-			propsData: {
-				image: imageFixtures[ 0 ]
-			},
-			store,
-			localVue
-		} );
+		getters.currentImage.mockReturnValue( imageFixtures[ 0 ] );
+		getters.currentImageSuggestions.mockReturnValue( imageFixtures[ 0 ].suggestions );
 
+		const wrapper = VueTestUtils.mount( ImageCard, { store, localVue } );
 		const publishButton = wrapper.find( '.wbmad-action-buttons__publish' );
 
 		expect( publishButton.attributes( 'disabled' ) ).toBe( 'disabled' );
 		expect( actions.publishTags ).not.toHaveBeenCalled();
+
 		publishButton.trigger( 'click' );
 		expect( actions.publishTags ).not.toHaveBeenCalled();
 	} );
 
-	it( 'dispatches the publish action when the publish button is clicked', done => {
-		const wrapper = VueTestUtils.mount( ImageCard, {
-			propsData: {
-				image: imageFixtures[ 0 ]
-			},
-			store,
-			localVue
-		} );
+	it( 'publish button is enabled when at least one suggestion is confirmed', () => {
+		let unconfirmedSuggestion = imageFixtures[ 0 ].suggestions[ 0 ];
+		let confirmedSuggestion = imageFixtures[ 0 ].suggestions[ 1 ];
+		confirmedSuggestion.confirmed = true;
 
+		getters.currentImage.mockReturnValue( imageFixtures[ 0 ] );
+		getters.currentImageSuggestions.mockReturnValue( [
+			unconfirmedSuggestion,
+			confirmedSuggestion
+		] );
+
+		const wrapper = VueTestUtils.mount( ImageCard, { store, localVue } );
 		const publishButton = wrapper.find( '.wbmad-action-buttons__publish' );
-		wrapper.vm.toggleConfirmed( wrapper.vm.suggestions[ 0 ] ); // confirm a suggestion to enable publish button
 
-		Vue.nextTick( () => {
-			expect( actions.publishTags ).not.toHaveBeenCalled();
-			publishButton.trigger( 'click' );
-			expect( actions.publishTags ).toHaveBeenCalled();
-			done();
-		} );
+		expect( publishButton.attributes( 'disabled' ) ).not.toBe( 'disabled' );
+	} );
+
+	it( 'dispatches the publish action when the publish button is clicked', () => {
+		let unconfirmedSuggestion = imageFixtures[ 0 ].suggestions[ 0 ];
+		let confirmedSuggestion = imageFixtures[ 0 ].suggestions[ 1 ];
+		confirmedSuggestion.confirmed = true;
+
+		getters.currentImage.mockReturnValue( imageFixtures[ 0 ] );
+		getters.currentImageSuggestions.mockReturnValue( [
+			unconfirmedSuggestion,
+			confirmedSuggestion
+		] );
+
+		const wrapper = VueTestUtils.mount( ImageCard, { store, localVue } );
+		const publishButton = wrapper.find( '.wbmad-action-buttons__publish' );
+
+		expect( actions.publishTags ).not.toHaveBeenCalled();
+
+		publishButton.trigger( 'click' );
+		expect( actions.publishTags ).toHaveBeenCalled();
 	} );
 
 	it( 'dispatches the skipImage action when the skip button is clicked', () => {
-		const wrapper = VueTestUtils.mount( ImageCard, {
-			propsData: {
-				image: imageFixtures[ 0 ]
-			},
-			store,
-			localVue
-		} );
+		getters.currentImage.mockReturnValue( imageFixtures[ 0 ] );
+		getters.currentImageSuggestions.mockReturnValue( imageFixtures[ 0 ].suggestions );
 
+		const wrapper = VueTestUtils.mount( ImageCard, { store, localVue } );
 		const skipButton = wrapper.find( '.wbmad-action-buttons__skip' );
 
 		expect( actions.skipImage ).not.toHaveBeenCalled();
+
 		skipButton.trigger( 'click' );
 		expect( actions.skipImage ).toHaveBeenCalled();
 	} );


### PR DESCRIPTION
Since we're using Vuex here, we may as well rely on it wherever possible to
simplify questions about the "source of truth" in the application. There is
really no need to pass things like Image or Suggestions down from one component
to another as props any onger. This lets us eliminate some code inside the
components and solves our previous problem of how to deal with the scenario
where ImageCard receives suggestions as part of its props and then mutates a
local copy of  the data.

* Adds a new Vuex getter, currentImageSuggestions, for use in components
* Adds a new action and mutation for toggling the state of a single suggestion;
  ImageCard dispatches the toggleTagConfirmation action every time a tag is
  clicked, with the tag in question as a payload. The action looks up the index
  of this suggestion in the current image. This index is provided as an
  argument to the toggleSuggestion mutation which changes the state of the
  suggestion in state. User experience remains unchanged.
* the publishTags action no longer needs any payload at all, since all the
  necessary data is already in Vuex
* Reworks the tests to reflect the new data flow; a little more mocking is
  necessary for now.

Change-Id: I04960309c0f8abbf1c20dd44de7c3ed189d6fb47