### PR TITLE
Handle URL fragments

### DIFF
--- a/resources/components/App.vue
+++ b/resources/components/App.vue
@@ -185,8 +185,8 @@ module.exports = {
 		// Otherwise, default to "popular" add a fragement to the URL.
 		var urlFragment = url.fragment,
 			hash = ( urlFragment && this.tabs.indexOf( urlFragment ) !== -1 ) ?
-			urlFragment :
-			this.tabs[ 0 ];
+				urlFragment :
+				this.tabs[ 0 ];
 		window.history.replaceState( null, null, '#' + hash );
 		this.updateCurrentTab( hash );
 

--- a/resources/components/App.vue
+++ b/resources/components/App.vue
@@ -102,12 +102,6 @@ module.exports = {
 		'card-stack': CardStack
 	},
 
-	data: function () {
-		return {
-			hash: url.fragment
-		};
-	},
-
 	computed: $.extend( {}, mapState( [
 		'currentTab',
 		'publishStatus'
@@ -165,6 +159,7 @@ module.exports = {
 		 * @param {VueComponent} tab
 		 */
 		onTabChange: function ( tab ) {
+			window.history.replaceState( null, null, '#' + tab.name );
 			this.updateCurrentTab( tab.name );
 		},
 
@@ -185,20 +180,14 @@ module.exports = {
 		}
 	} ),
 
-	watch: {
-		hash: function ( newHash ) {
-			if ( this.tabs.indexOf( newHash ) !== -1 ) {
-				this.updateCurrentTab( this.hash );
-			}
-		}
-	},
-
 	mounted: function () {
 		// If there's a URL fragment and it's one of the tabs, select that tab.
 		// Otherwise, default to "popular" add a fragement to the URL.
-		var hash = ( this.hash && this.tabs.indexOf( this.hash ) !== -1 ) ?
-			this.hash :
+		var urlFragment = url.fragment,
+			hash = ( urlFragment && this.tabs.indexOf( urlFragment ) !== -1 ) ?
+			urlFragment :
 			this.tabs[ 0 ];
+		window.history.replaceState( null, null, '#' + hash );
 		this.updateCurrentTab( hash );
 
 		// Listen for hash changes.

--- a/resources/components/CardStack.vue
+++ b/resources/components/CardStack.vue
@@ -127,6 +127,7 @@ module.exports = {
 		'updateCurrentTab'
 	] ), {
 		goToPopularTab: function () {
+			window.history.replaceState( null, null, '#popular' );
 			this.updateCurrentTab( 'popular' );
 		}
 	} ),

--- a/resources/store/index.js
+++ b/resources/store/index.js
@@ -197,7 +197,6 @@ module.exports = new Vuex.Store( {
 		 */
 		setTab: function ( state, tabName ) {
 			ensureTabExists( state, tabName );
-			window.history.replaceState( null, null, '#' + tabName );
 			state.currentTab = tabName;
 		},
 

--- a/resources/store/index.js
+++ b/resources/store/index.js
@@ -197,6 +197,7 @@ module.exports = new Vuex.Store( {
 		 */
 		setTab: function ( state, tabName ) {
 			ensureTabExists( state, tabName );
+			window.history.replaceState( null, null, '#' + tabName );
 			state.currentTab = tabName;
 		},
 
@@ -429,6 +430,8 @@ module.exports = new Vuex.Store( {
 					batch: JSON.stringify( reviewBatch )
 				} );
 
+			// TODO: Show pending state.
+
 			// TODO: this is where we should request more images if we are
 			// running low in a given queue
 
@@ -440,6 +443,7 @@ module.exports = new Vuex.Store( {
 			} ).fail( function () {
 				context.dispatch( 'updatePublishStatus', 'error' );
 			} ).always( function () {
+				// TODO: remove pending state.
 				context.dispatch( 'skipImage' );
 			} );
 		},

--- a/resources/store/index.js
+++ b/resources/store/index.js
@@ -429,8 +429,6 @@ module.exports = new Vuex.Store( {
 					batch: JSON.stringify( reviewBatch )
 				} );
 
-			// TODO: Show pending state.
-
 			// TODO: this is where we should request more images if we are
 			// running low in a given queue
 
@@ -442,7 +440,6 @@ module.exports = new Vuex.Store( {
 			} ).fail( function () {
 				context.dispatch( 'updatePublishStatus', 'error' );
 			} ).always( function () {
-				// TODO: remove pending state.
 				context.dispatch( 'skipImage' );
 			} );
 		},

--- a/tests/jest/App.test.js
+++ b/tests/jest/App.test.js
@@ -36,7 +36,10 @@ describe( 'App', () => {
 		getters = {
 			isAuthenticated: jest.fn(),
 			isAutoconfirmed: jest.fn(),
-			currentImage: jest.fn() // needed for tests that use deep mounting
+			currentImage: jest.fn(), // needed for tests that use deep mounting
+			tabs: function ( state ) {
+				return Object.keys( state.images );
+			}
 		};
 
 		actions = {
@@ -104,10 +107,11 @@ describe( 'App', () => {
 		} );
 
 		// Expect the updateCurrentTab action to be dispatched
-		expect( actions.updateCurrentTab.mock.calls.length ).toBe( 1 );
+		// (The first time it was called was on mount)
+		expect( actions.updateCurrentTab.mock.calls.length ).toBe( 2 );
 
 		// Expect the call to updateCurrentTab to contain the correct payload
-		expect( actions.updateCurrentTab.mock.calls[ 0 ][ 1 ] ).toBe( 'user' );
+		expect( actions.updateCurrentTab.mock.calls[ 1 ][ 1 ] ).toBe( 'user' );
 	} );
 
 	it( 'dispatches a getImages action for user images when mounted', () => {


### PR DESCRIPTION
This commit makes the following possible:
- Setting tab based on initial URL fragment
- Changing fragment on tab change
- Listening for hash changes and changing tabs when they happen
