### PR TITLE
Ditch initial batch and show categories

### DIFF
--- a/resources/components/App.vue
+++ b/resources/components/App.vue
@@ -183,20 +183,24 @@ module.exports = {
 	mounted: function () {
 		// If there's a URL fragment and it's one of the tabs, select that tab.
 		// Otherwise, default to "popular" add a fragement to the URL.
-		var urlFragment = url.fragment,
+		var i,
+			urlFragment = url.fragment,
 			hash = ( urlFragment && this.tabs.indexOf( urlFragment ) !== -1 ) ?
 				urlFragment :
 				this.tabs[ 0 ];
+
+		// Fetch initial image batches.
+		for ( i = 0; i < this.tabs.length; i++ ) {
+			this.getImages( { queue: this.tabs[ i ] } );
+		}
+
 		window.history.replaceState( null, null, '#' + hash );
 		this.updateCurrentTab( hash );
 
 		// Listen for hash changes.
 		window.addEventListener( 'hashchange', this.onHashChange );
 
-		// Fetch batch of images.
-		this.getImages( {
-			queue: hash
-		} );
+
 	}
 };
 </script>

--- a/resources/components/App.vue
+++ b/resources/components/App.vue
@@ -199,8 +199,6 @@ module.exports = {
 
 		// Listen for hash changes.
 		window.addEventListener( 'hashchange', this.onHashChange );
-
-
 	}
 };
 </script>

--- a/resources/components/App.vue
+++ b/resources/components/App.vue
@@ -193,11 +193,9 @@ module.exports = {
 		// Listen for hash changes.
 		window.addEventListener( 'hashchange', this.onHashChange );
 
-		// popular images are pre-loaded on the server side;
-		// immediately fetch user images in the mounted hook so that they'll be
-		// ready for the user if they switch tabs
+		// Fetch batch of images.
 		this.getImages( {
-			queue: 'user'
+			queue: hash
 		} );
 	}
 };

--- a/resources/components/App.vue
+++ b/resources/components/App.vue
@@ -183,16 +183,14 @@ module.exports = {
 	mounted: function () {
 		// If there's a URL fragment and it's one of the tabs, select that tab.
 		// Otherwise, default to "popular" add a fragement to the URL.
-		var i,
-			urlFragment = url.fragment,
+		var urlFragment = url.fragment,
 			hash = ( urlFragment && this.tabs.indexOf( urlFragment ) !== -1 ) ?
 				urlFragment :
 				this.tabs[ 0 ];
 
-		// Fetch initial image batches.
-		for ( i = 0; i < this.tabs.length; i++ ) {
-			this.getImages( { queue: this.tabs[ i ] } );
-		}
+		this.tabs.forEach( function ( tab ) {
+			this.getImages( { queue: tab } );
+		}.bind( this ) );
 
 		window.history.replaceState( null, null, '#' + hash );
 		this.updateCurrentTab( hash );

--- a/resources/components/ImageCard.vue
+++ b/resources/components/ImageCard.vue
@@ -16,7 +16,16 @@
 					</a>
 				</label>
 
-				<!-- TODO: categories. -->
+				<div v-if="hasCategories" class="wbmad-category-list">
+					<span
+						v-i18n-html:machinevision-categories-label
+						class="wbmad-category-list__label" />
+					<span
+						v-for="( category, index ) in categories"
+						v-bind:key="category + index"
+						class="wbmad-category-list__item"
+					>{{ category }}</span>
+				</div>
 
 				<div class="wbmad-image-with-suggestions__tags">
 					<suggestion v-for="( suggestion, index ) in currentImageSuggestions"
@@ -91,6 +100,20 @@ module.exports = {
 		 */
 		descriptionUrl: function () {
 			return this.currentImage.descriptionurl;
+		},
+
+		/**
+		 * @return {boolean}
+		 */
+		hasCategories: function () {
+			return this.categories.length > 0;
+		},
+
+		/**
+		 * @return {Array}
+		 */
+		categories: function () {
+			return this.currentImage.categories;
 		},
 
 		publishDisabled: function () {
@@ -203,6 +226,38 @@ module.exports = {
 		.flex-display();
 		.flex-wrap( wrap );
 		margin: 18px 0;
+	}
+}
+
+.wbmad-category-list {
+	.fade-in( 0.2s );
+	margin: 4px 0 0;
+
+	span {
+		color: @base20;
+		font-size: 0.928em;
+	}
+}
+
+.wbmad-category-list__label {
+	margin: 0 0.4em 0 0;
+}
+
+// This isn't _exactly_ ideal, and spacing this pipe-deliminated list would be
+// more exact if we used flexbox. However, we need the text to wrap like a
+// paragraph, so we'll get as close as we can with a border-right and some magic
+// numbers. We'll at least explicitly set the word-spacing to normal to maximize
+// the chance that the spacing looks even.
+.wbmad-category-list__item {
+	border-right: solid 1px @base20;
+	margin: 0 0.4em 0 0;
+	padding-right: 0.4em;
+	word-spacing: normal;
+
+	&:last-child {
+		border-right: 0;
+		margin: 0;
+		padding: 0;
 	}
 }
 

--- a/resources/store/actions.js
+++ b/resources/store/actions.js
@@ -9,7 +9,8 @@ var MvImage = require( '../models/Image.js' ),
 	datamodel = require( 'wikibase.datamodel' ),
 	serialization = require( 'wikibase.serialization' ),
 	mvConfig = require( 'ext.MachineVision.config' ),
-	ensureTabExists = require( './utils.js' ).ensureTabExists;
+	ensureTabExists = require( './utils.js' ).ensureTabExists,
+	getCategories = require( './utils.js' ).getCategories;
 
 module.exports = {
 	/**
@@ -40,12 +41,14 @@ module.exports = {
 				formatversion: 2,
 				generator: 'unreviewedimagelabels',
 				guillimit: 10,
-				prop: 'imageinfo|imagelabels',
+				prop: 'imageinfo|imagelabels|categories',
 				iiprop: 'url',
 				iiurlwidth: 800,
 				ilstate: 'unreviewed',
 				meta: 'unreviewedimagecount',
-				uselang: mw.config.get( 'wgUserLanguage' )
+				uselang: mw.config.get( 'wgUserLanguage' ),
+				cllimit: 500,
+				clshow: '!hidden'
 			};
 
 		ensureTabExists( context.state, queue );
@@ -85,7 +88,8 @@ module.exports = {
 					item.imageinfo[ 0 ].thumbheight,
 					item.imagelabels.map( function ( labelData ) {
 						return new MvSuggestion( labelData.label, labelData.wikidata_id );
-					} )
+					} ),
+					getCategories( item )
 				);
 			} );
 

--- a/resources/store/state.js
+++ b/resources/store/state.js
@@ -1,14 +1,10 @@
 'use strict';
 
-/* eslint-disable no-implicit-globals */
-var processInitialData = require( './utils.js' ).processInitialData,
-	initialData = mw.config.get( 'wgMVSuggestedTagsInitialData' ) || [];
-
 module.exports = {
 	currentTab: 'popular',
 
 	images: {
-		popular: processInitialData( initialData ),
+		popular: [],
 		user: []
 	},
 

--- a/resources/store/utils.js
+++ b/resources/store/utils.js
@@ -1,39 +1,5 @@
 'use strict';
 
-/* eslint-disable no-implicit-globals */
-var MvImage = require( '../models/Image.js' ),
-	MvSuggestion = require( '../models/Suggestion.js' );
-
-/**
- * Helper function to normalize the data we get upfront and the data we get
- * from future API requests
- *
- * @param {Array} data
- * @return {ImageData[]}
- */
-module.exports.processInitialData = function processInitialData( data ) {
-	return data.map( function ( item ) {
-		var height = item.height,
-			width = item.width;
-
-		// Find thumbheight for images wider than 800px.
-		if ( width > 800 ) {
-			height = height * 800 / width;
-		}
-
-		return new MvImage(
-			item.title,
-			item.pageid,
-			item.description_url,
-			item.thumb_url,
-			height,
-			item.suggested_labels.map( function ( labelData ) {
-				return new MvSuggestion( labelData.label, labelData.wikidata_id );
-			} )
-		);
-	} );
-};
-
 /**
  * Helper function to ensure the user doesn't try to access an invalid tab.
  *
@@ -46,4 +12,27 @@ module.exports.ensureTabExists = function ensureTabExists( state, tab ) {
 	if ( tabs.indexOf( tab ) === -1 ) {
 		throw new Error( 'invalid tab' );
 	}
+};
+
+/**
+ * Get categories for an image.
+ * @param {Object} item
+ * @return {Array}
+ */
+module.exports.getCategories = function ( item ) {
+	var categories = [],
+		titlePrefix,
+		sliceStart;
+
+	if ( item.categories && item.categories.length > 0 ) {
+		titlePrefix = 'Category:';
+		sliceStart = titlePrefix.length;
+
+		categories = item.categories.map( function ( category ) {
+			// Strip out the "Category:" string.
+			return category.title.slice( sliceStart );
+		} );
+	}
+
+	return categories;
 };

--- a/tests/jest/App.test.js
+++ b/tests/jest/App.test.js
@@ -114,13 +114,13 @@ describe( 'App', () => {
 		expect( actions.updateCurrentTab.mock.calls[ 1 ][ 1 ] ).toBe( 'user' );
 	} );
 
-	it( 'dispatches a getImages action for user images when mounted', () => {
+	it( 'dispatches a getImages action for each queue when mounted', () => {
 		getters.isAuthenticated.mockReturnValue( true );
 		getters.isAutoconfirmed.mockReturnValue( true );
 
 		// Expect the getImages action to be dispatched when component is mounted
 		expect( actions.getImages.mock.calls.length ).toBe( 0 );
 		VueTestUtils.shallowMount( App, { store, localVue, computed } );
-		expect( actions.getImages.mock.calls.length ).toBe( 1 );
+		expect( actions.getImages.mock.calls.length ).toBe( 2 );
 	} );
 } );

--- a/tests/jest/actions.test.js
+++ b/tests/jest/actions.test.js
@@ -60,11 +60,14 @@ describe( 'getters', () => {
 					formatversion: 2,
 					generator: 'unreviewedimagelabels',
 					guillimit: 10,
-					prop: 'imageinfo|imagelabels',
+					prop: 'imageinfo|imagelabels|categories',
 					iiprop: 'url',
 					iiurlwidth: 800,
 					ilstate: 'unreviewed',
-					meta: 'unreviewedimagecount'
+					meta: 'unreviewedimagecount',
+					uselang: mw.config.get( 'wgUserLanguage' ),
+					cllimit: 500,
+					clshow: '!hidden'
 				} )
 			);
 		} );

--- a/tests/jest/fixtures/apiResponse.json
+++ b/tests/jest/fixtures/apiResponse.json
@@ -58,6 +58,20 @@
 						"description": "public thoroughfare in a built environment",
 						"alias": "St."
 					}
+				],
+				"categories": [
+					{
+						"ns": 14,
+						"title": "Category:Photographs"
+					},
+					{
+						"ns": 14,
+						"title": "Category:Photographs of people"
+					},
+					{
+						"ns": 14,
+						"title": "Category:Streets"
+					}
 				]
 			},
 			{
@@ -176,7 +190,8 @@
 						"description": "monochrome form in visual arts",
 						"alias": "black and white"
 					}
-				]
+				],
+				"categories": []
 			},
 			{
 				"pageid": 25,
@@ -214,7 +229,8 @@
 						"description": "structure, typically with a roof and walls, standing more or less permanently in one place",
 						"alias": "edifice"
 					}
-				]
+				],
+				"categories": []
 			}
 		],
 		"unreviewedimagecount": {

--- a/tests/jest/fixtures/imageData.json
+++ b/tests/jest/fixtures/imageData.json
@@ -16,6 +16,11 @@
 				"wikidataId": "Q7561",
 				"confirmed": false
 			}
+		],
+		"categories": [
+			"Photographs",
+			"Photographs of people",
+			"Streets"
 		]
 	},
 	{
@@ -45,7 +50,8 @@
 				"wikidataId": "Q79007",
 				"confirmed": false
 			}
-		]
+		],
+		"categories": []
 	},
 	{
 		"title": "File:Fullsizeinput 2d0.jpg",
@@ -104,7 +110,8 @@
 				"wikidataId": "Q838368",
 				"confirmed": false
 			}
-		]
+		],
+		"categories": []
 	},
 	{
 		"title": "File:Fullsizeinput 2cb.jpg",
@@ -123,6 +130,7 @@
 				"wikidataId": "Q41176",
 				"confirmed": false
 			}
-		]
+		],
+		"categories": []
 	}
 ]


### PR DESCRIPTION
- Remove use of the initial batch on the front end. We can pull in the related backend changes from master once they're merged, but at least we'll be ready to go on the frontend
- Show categories if they exist
