### PR TITLE
Show user's unreviewed image count

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -233,6 +233,7 @@
 				"components/Spinner.vue",
 				"components/ImageCard.vue",
 				"components/UserMessage.vue",
+				"components/PersonalUploadsCount.vue",
 				"components/base/Button.vue",
 				"components/base/Icon.vue",
 				"components/base/Message.vue",

--- a/resources/components/App.vue
+++ b/resources/components/App.vue
@@ -27,14 +27,13 @@
 
 			<tabs v-bind:active="currentTab" v-on:tab-change="onTabChange">
 				<!-- Popular tab -->
-				<tab name="popular"
-					v-bind:title="popularTabTitle">
+				<tab name="popular" v-bind:title="popularTabTitle">
 					<card-stack v-bind:queue="'popular'" />
 				</tab>
 
 				<!-- User tab -->
-				<tab name="user"
-					v-bind:title="userTabTitle">
+				<tab name="user" v-bind:title="userTabTitle">
+					<personal-uploads-count />
 					<card-stack v-bind:queue="'user'" />
 				</tab>
 			</tabs>
@@ -89,6 +88,7 @@ var mapState = require( 'vuex' ).mapState,
 	Tab = require( './base/Tab.vue' ),
 	ToastNotification = require( './base/ToastNotification.vue' ),
 	CardStack = require( './CardStack.vue' ),
+	PersonalUploadsCount = require( './PersonalUploadsCount.vue' ),
 	url = new mw.Uri();
 
 // @vue/component
@@ -99,7 +99,8 @@ module.exports = {
 		tabs: Tabs,
 		tab: Tab,
 		'toast-notification': ToastNotification,
-		'card-stack': CardStack
+		'card-stack': CardStack,
+		'personal-uploads-count': PersonalUploadsCount
 	},
 
 	computed: $.extend( {}, mapState( [

--- a/resources/components/PersonalUploadsCount.vue
+++ b/resources/components/PersonalUploadsCount.vue
@@ -1,0 +1,24 @@
+<template>
+	<div class="wbmad-personal-uploads-count">
+		<p>{{ $i18n( 'machinevision-personal-uploads-count', unreviewedCount ) }}</p>
+	</div>
+</template>
+
+<script>
+var mapState = require( 'vuex' ).mapState;
+
+module.exports = {
+	name: 'PersonalUploadsCount',
+
+	computed: $.extend( {}, mapState( [
+		'unreviewedCount'
+	] ) )
+};
+</script>
+
+<style lang="less">
+.wbmad-personal-uploads-count {
+	font-weight: bold;
+	margin-bottom: 1em;
+}
+</style>

--- a/resources/components/PersonalUploadsCount.vue
+++ b/resources/components/PersonalUploadsCount.vue
@@ -1,5 +1,6 @@
 <template>
-	<div class="wbmad-personal-uploads-count">
+	<div v-if="unreviewedCount > 0"
+		class="wbmad-personal-uploads-count">
 		<p>{{ $i18n( 'machinevision-personal-uploads-count', unreviewedCount ) }}</p>
 	</div>
 </template>
@@ -17,8 +18,15 @@ module.exports = {
 </script>
 
 <style lang="less">
+@import '../style-variables.less';
+
 .wbmad-personal-uploads-count {
+	.fade-in( 0.5s );
 	font-weight: bold;
-	margin-bottom: 1em;
+	margin-bottom: 16px;
+
+	p {
+		margin: 0;
+	}
 }
 </style>

--- a/resources/store/actions.js
+++ b/resources/store/actions.js
@@ -101,10 +101,14 @@ module.exports = {
 				} );
 			} );
 
-			context.commit( 'setUserStats', res.query.unreviewedimagecount.user );
-
-			// Commit the current number of unreviewed personal images into the store
-			context.commit( 'setUnreviewedCount', res.query.unreviewedimagecount.user.unreviewed );
+			try {
+				// Commit user stats and current number of unreviewed personal
+				// images into the store.
+				context.commit( 'setUserStats', res.query.unreviewedimagecount.user );
+				context.commit( 'setUnreviewedCount', res.query.unreviewedimagecount.user.unreviewed );
+			} catch ( e ) {
+				// Use default state values.
+			}
 
 			// Remove the pending state
 			context.commit( 'setPending', {

--- a/resources/store/mutations.js
+++ b/resources/store/mutations.js
@@ -95,5 +95,21 @@ module.exports = {
 
 	setUserStats: function ( state, payload ) {
 		state.userStats = payload;
+	},
+
+	/**
+	 * Set the initial count of user's unreviewed images
+	 * @param {Object} state
+	 * @param {number} count
+	 */
+	setUnreviewedCount: function ( state, count ) {
+		state.unreviewedCount = count;
+	},
+
+	/**
+	 * @param {Object} state
+	 */
+	decrementUnreviewedCount: function ( state ) {
+		state.unreviewedCount--;
 	}
 };

--- a/resources/store/state.js
+++ b/resources/store/state.js
@@ -13,6 +13,8 @@ module.exports = {
 		user: false
 	},
 
+	unreviewedCount: 0,
+
 	/**
 	 * @TODO Currently four possible status states exist:
 	 * - "success"

--- a/tests/jest/actions.test.js
+++ b/tests/jest/actions.test.js
@@ -363,6 +363,10 @@ describe( 'getters', () => {
 				get: jest.fn().mockReturnValue( 'Test' )
 			} );
 
+			Object.defineProperty( context.getters, 'currentImageNonDisplayableSuggestions', {
+				get: jest.fn().mockReturnValue( [] )
+			} );
+
 			actions.publishTags( context );
 
 			promise.always( () => {
@@ -388,6 +392,10 @@ describe( 'getters', () => {
 
 			Object.defineProperty( context.getters, 'currentImageTitle', {
 				get: jest.fn().mockReturnValue( 'Test' )
+			} );
+
+			Object.defineProperty( context.getters, 'currentImageNonDisplayableSuggestions', {
+				get: jest.fn().mockReturnValue( [] )
 			} );
 
 			actions.publishTags( context );


### PR DESCRIPTION
* Adds the unreviewed image count to Vuex: getImages action sets the value, and
  successful publication of image while user tab is active decrements value.
* Adds a simple PersonalUploadsCount component which displays this value
* Add tests for the updated Vuex actions
