### PR TITLE
Set the state of non-displayable labels when tags are published

### DIFF
--- a/resources/store/actions.js
+++ b/resources/store/actions.js
@@ -129,41 +129,48 @@ module.exports = {
 	},
 
 	/**
-	 * @TODO implement this
-	 *
 	 * submits user selections for current image to API and commits the
-	 * mutations for removing image from queue; can also dispatch getImages if
-	 * we are running low on data
+	 * mutations for removing image from queue
 	 *
 	 * @param {Object} context
 	 */
 	publishTags: function ( context ) {
-		var tags = context.getters.currentImageSuggestions,
-			reviewBatch = tags.map( function ( tag ) {
-				return {
-					label: tag.wikidataId,
-					review: tag.confirmed ? 'accept' : 'reject'
-				};
-			} ),
-			confirmedTags = tags.filter( function ( tag ) {
+		var displayedTags = context.getters.currentImageSuggestions,
+			nonDisplayedTags = context.getters.currentImageNonDisplayableSuggestions,
+			confirmedTags = displayedTags.filter( function ( tag ) {
 				return tag.confirmed;
 			} ),
-			setClaims = context.dispatch( 'setDepictsStatements', confirmedTags ),
-			reviewImageLabels = api.postWithToken( 'csrf', {
-				action: 'reviewimagelabels',
-				filename: context.getters.currentImageTitle,
-				batch: JSON.stringify( reviewBatch )
+			setClaimsRequest = context.dispatch( 'setDepictsStatements', confirmedTags ),
+			reviewBatch,
+			reviewImageLabelsRequest;
+
+		// Set the review state for all tags which could be displayed to the user
+		reviewBatch = displayedTags.map( function ( tag ) {
+			return {
+				label: tag.wikidataId,
+				review: tag.confirmed ? 'accept' : 'reject'
+			};
+		} );
+
+		// If there were any tags which could not be displayed to the user in their language,
+		// set them to the "not-displayed" state
+		nonDisplayedTags.forEach( function ( tag ) {
+			reviewBatch.push( {
+				label: tag.wikidataId,
+				review: 'not-displayed'
 			} );
+		} );
+
+		reviewImageLabelsRequest = api.postWithToken( 'csrf', {
+			action: 'reviewimagelabels',
+			filename: context.getters.currentImageTitle,
+			batch: JSON.stringify( reviewBatch )
+		} );
 
 		context.dispatch( 'updatePublishStatus', 'pending' );
 
-		// TODO: this is where we should request more images if we are
-		// running low in a given queue
-
-		// TODO: this is where we should be logging some data
-
 		// Set claims, review labels, update publish status, and skip to next image
-		$.when( setClaims, reviewImageLabels ).done( function () {
+		$.when( setClaimsRequest, reviewImageLabelsRequest ).done( function () {
 			context.dispatch( 'updatePublishStatus', 'success' );
 		} ).fail( function () {
 			context.dispatch( 'updatePublishStatus', 'error' );

--- a/resources/store/getters.js
+++ b/resources/store/getters.js
@@ -65,6 +65,17 @@ module.exports = {
 		}
 	},
 
+	currentImageNonDisplayableSuggestions: function ( state, getters ) {
+		if ( getters.currentImage ) {
+			// Return *only* suggestions with no label
+			return getters.currentImage.suggestions.filter( function ( suggestion ) {
+				return !suggestion.text;
+			} );
+		} else {
+			return [];
+		}
+	},
+
 	/**
 	 * Whether or not the user is logged in. Derived from non-Vuex global
 	 * state.

--- a/tests/jest/actions.test.js
+++ b/tests/jest/actions.test.js
@@ -162,6 +162,10 @@ describe( 'getters', () => {
 				get: jest.fn().mockReturnValue( suggestions )
 			} );
 
+			Object.defineProperty( context.getters, 'currentImageNonDisplayableSuggestions', {
+				get: jest.fn().mockReturnValue( [] )
+			} );
+
 			actions.publishTags( context );
 			expect( context.dispatch ).toHaveBeenCalledWith( 'setDepictsStatements', confirmed );
 		} );
@@ -187,6 +191,10 @@ describe( 'getters', () => {
 
 			Object.defineProperty( context.getters, 'currentImageTitle', {
 				get: jest.fn().mockReturnValue( 'Test' )
+			} );
+
+			Object.defineProperty( context.getters, 'currentImageNonDisplayableSuggestions', {
+				get: jest.fn().mockReturnValue( [] )
 			} );
 
 			actions.publishTags( context );
@@ -217,6 +225,10 @@ describe( 'getters', () => {
 				get: jest.fn().mockReturnValue( 'Test' )
 			} );
 
+			Object.defineProperty( context.getters, 'currentImageNonDisplayableSuggestions', {
+				get: jest.fn().mockReturnValue( [] )
+			} );
+
 			actions.publishTags( context );
 
 			promise.always( () => {
@@ -242,6 +254,10 @@ describe( 'getters', () => {
 
 			Object.defineProperty( context.getters, 'currentImageTitle', {
 				get: jest.fn().mockReturnValue( 'Test' )
+			} );
+
+			Object.defineProperty( context.getters, 'currentImageNonDisplayableSuggestions', {
+				get: jest.fn().mockReturnValue( [] )
 			} );
 
 			actions.publishTags( context );
@@ -271,6 +287,10 @@ describe( 'getters', () => {
 				get: jest.fn().mockReturnValue( 'Test' )
 			} );
 
+			Object.defineProperty( context.getters, 'currentImageNonDisplayableSuggestions', {
+				get: jest.fn().mockReturnValue( [] )
+			} );
+
 			actions.publishTags( context );
 
 			promise.always( () => {
@@ -296,6 +316,10 @@ describe( 'getters', () => {
 
 			Object.defineProperty( context.getters, 'currentImageTitle', {
 				get: jest.fn().mockReturnValue( 'Test' )
+			} );
+
+			Object.defineProperty( context.getters, 'currentImageNonDisplayableSuggestions', {
+				get: jest.fn().mockReturnValue( [] )
 			} );
 
 			actions.publishTags( context );


### PR DESCRIPTION
* Adds a new Vuex getter, currentImageNonDisplayableSuggestions. This getter
  returns all suggestions for the current image which lack labels.
* Updates the pubishTags action to add these non-displayed labels to the review
  batch with a value of "not-displayed"
* Updates the test suite