### PR TITLE
Refactor base components to use WMUI base variables

### DIFF
--- a/resources/components/ImageCard.vue
+++ b/resources/components/ImageCard.vue
@@ -52,7 +52,7 @@
 					</mw-button>
 					<mw-button
 						class="wbmad-action-buttons__skip"
-						v-bind:unframed="true"
+						v-bind:frameless="true"
 						v-bind:disabled="skipDisabled"
 						v-bind:title="$i18n( 'machinevision-skip-title', title ).parse()"
 						v-on:click="onSkip"

--- a/resources/components/ImageCard.vue
+++ b/resources/components/ImageCard.vue
@@ -52,7 +52,7 @@
 					</mw-button>
 					<mw-button
 						class="wbmad-action-buttons__skip"
-						v-bind:framed="false"
+						v-bind:unframed="true"
 						v-bind:disabled="skipDisabled"
 						v-bind:title="$i18n( 'machinevision-skip-title', title ).parse()"
 						v-on:click="onSkip"

--- a/resources/components/base/Button.vue
+++ b/resources/components/base/Button.vue
@@ -29,7 +29,7 @@ module.exports = {
 		disabled: {
 			type: Boolean
 		},
-		unframed: {
+		frameless: {
 			type: Boolean
 		},
 		icon: {
@@ -54,7 +54,7 @@ module.exports = {
 	computed: {
 		builtInClasses: function () {
 			return {
-				'mw-button--framed': !this.unframed,
+				'mw-button--framed': !this.frameless,
 				'mw-button--icon': this.icon,
 				'mw-button--progressive': this.progressive,
 				'mw-button--destructive': this.destructive,
@@ -62,7 +62,7 @@ module.exports = {
 			};
 		},
 		invert: function () {
-			return ( this.primary || this.disabled ) && !this.unframed;
+			return ( this.primary || this.disabled ) && !this.frameless;
 		}
 	}
 };

--- a/resources/components/base/Button.vue
+++ b/resources/components/base/Button.vue
@@ -27,12 +27,10 @@ module.exports = {
 
 	props: {
 		disabled: {
-			type: Boolean,
-			default: false
+			type: Boolean
 		},
-		framed: {
-			type: Boolean,
-			default: true
+		unframed: {
+			type: Boolean
 		},
 		icon: {
 			type: String,
@@ -43,23 +41,20 @@ module.exports = {
 		// a bit more readable and intuitive, plus it makes the code in this
 		// component simpler.
 		progressive: {
-			type: Boolean,
-			default: false
+			type: Boolean
 		},
 		destructive: {
-			type: Boolean,
-			default: false
+			type: Boolean
 		},
 		primary: {
-			type: Boolean,
-			default: false
+			type: Boolean
 		}
 	},
 
 	computed: {
 		builtInClasses: function () {
 			return {
-				'mw-button--framed': this.framed,
+				'mw-button--framed': !this.unframed,
 				'mw-button--icon': this.icon,
 				'mw-button--progressive': this.progressive,
 				'mw-button--destructive': this.destructive,
@@ -67,7 +62,7 @@ module.exports = {
 			};
 		},
 		invert: function () {
-			return ( this.primary || this.disabled && this.framed );
+			return ( this.primary || this.disabled ) && !this.unframed;
 		}
 	}
 };
@@ -75,23 +70,23 @@ module.exports = {
 
 <style lang="less">
 @import 'mediawiki.mixins';
-@import '../../style-variables.less';
+@import '../../../lib/wikimedia-ui-base.less';
 
 .mw-button {
+	.transition( ~'background-color 100ms, color 100ms, border-color 100ms, box-shadow 100ms' );
 	background-color: transparent;
 	border: 0;
-	color: @base10;
+	color: @color-base;
 	cursor: pointer;
 	font-size: inherit;
 	font-weight: bold;
 	padding: 6px;
-	transition: background-color 100ms, color 100ms, border-color 100ms, box-shadow 100ms;
 	user-select: none;
 
 	&:hover,
 	&:focus {
 		background-color: rgba( 0, 24, 73, 0.02745098 );
-		color: @base0;
+		color: @color-base--emphasized;
 	}
 
 	.mw-icon {
@@ -114,15 +109,15 @@ module.exports = {
 	}
 
 	&--framed {
-		background-color: @base90;
-		border: 1px solid @base50;
+		background-color: @background-color-framed;
+		border: @border-base;
 		border-radius: 2px;
 		padding: 6px 12px;
 
 		&:hover,
 		&:focus {
-			background-color: @base100;
-			color: @base10-hover;
+			background-color: @background-color-framed--hover;
+			color: @color-base--hover;
 		}
 
 		&.mw-button--icon {
@@ -137,35 +132,35 @@ module.exports = {
 	}
 
 	&--progressive {
-		color: @progressive;
+		color: @color-primary;
 
 		&:hover,
 		&:focus {
-			color: @progressive-hover;
+			color: @color-primary--hover;
 		}
 
 		&.mw-button--framed {
 			&:hover,
 			&:focus {
-				border-color: @progressive;
-				color: @progressive;
+				border-color: @color-primary;
+				color: @color-primary;
 			}
 		}
 	}
 
 	&--destructive {
-		color: @destructive;
+		color: @color-destructive;
 
 		&:hover,
 		&:focus {
-			color: @destructive-hover;
+			color: @color-destructive--hover;
 		}
 
 		&.mw-button--framed {
 			&:hover,
 			&:focus {
-				border-color: @destructive;
-				color: @destructive;
+				border-color: @color-destructive;
+				color: @color-destructive;
 			}
 		}
 	}
@@ -173,51 +168,51 @@ module.exports = {
 	&--primary {
 		&.mw-button--framed {
 			// Default to progressive.
-			background-color: @progressive;
-			border-color: @progressive;
-			color: @base100;
+			background-color: @color-primary;
+			border-color: @color-primary;
+			color: @color-base--inverted;
 
 			&:hover,
 			&:focus {
-				background-color: @progressive-hover;
-				border-color: @progressive-hover;
-				box-shadow: inset 0 0 0 1px @progressive-hover;
-				color: @base100;
+				background-color: @color-primary--hover;
+				border-color: @color-primary--hover;
+				box-shadow: inset 0 0 0 1px @color-primary--hover;
+				color: @color-base--inverted;
 			}
 
 			&.mw-button--destructive {
-				background-color: @destructive;
-				border-color: @destructive;
+				background-color: @color-destructive;
+				border-color: @color-destructive;
 
 				&:hover,
 				&:focus {
-					background-color: @destructive-hover;
-					border-color: @destructive-hover;
-					box-shadow: inset 0 0 0 1px @destructive-hover;
+					background-color: @color-destructive--hover;
+					border-color: @color-destructive--hover;
+					box-shadow: inset 0 0 0 1px @color-destructive--hover;
 				}
 			}
 		}
 	}
 
 	&:disabled {
-		color: @base30;
+		color: @color-base--disabled;
 		cursor: auto;
 
 		&:hover,
 		&:focus {
-			background-color: @base100;
+			background-color: @background-color-base;
 		}
 
 		&.mw-button--framed {
-			background-color: @base70;
-			border-color: @base70;
-			color: @base100;
+			background-color: @background-color-filled--disabled;
+			border-color: @border-color-base--disabled;
+			color: @color-base--inverted;
 
 			&:hover,
 			&:focus {
-				background-color: @base70;
-				border-color: @base70;
-				box-shadow: inset 0 0 0 1px @base70;
+				background-color: @background-color-filled--disabled;
+				border-color: @border-color-base--disabled;
+				box-shadow: inset 0 0 0 1px @background-color-filled--disabled;
 			}
 		}
 

--- a/resources/components/base/Message.vue
+++ b/resources/components/base/Message.vue
@@ -24,6 +24,7 @@ var Icon = require( './Icon.vue' ),
 		success: 'check'
 	};
 
+// @vue/component
 module.exports = {
 	name: 'Message',
 
@@ -62,45 +63,45 @@ module.exports = {
 
 <style lang="less">
 @import 'mediawiki.mixins';
-@import '../../style-variables.less';
+@import '../../../lib/wikimedia-ui-base.less';
 
 .mw-message {
+	color: @color-notice;
 	font-weight: bold;
 	max-width: 50em;
 	position: relative;
 
 	&--error {
-		color: @errorColor;
+		color: @color-error;
 	}
 
 	&--success {
-		color: @successColor;
+		color: @color-success;
 	}
 
 	&--block {
-		border: 1px solid;
-		color: @base10;
+		color: @color-notice;
 		font-weight: normal;
 		padding: 16px 24px;
 
 		&.mw-message--notice {
-			background-color: @base80;
-			border-color: @base50;
+			background-color: @background-color-notice--framed;
+			border: @border-notice;
 		}
 
 		&.mw-message--error {
-			background-color: @errorBackground;
-			border-color: @errorBorder;
+			background-color: @background-color-error--framed;
+			border: @border-error;
 		}
 
 		&.mw-message--warning {
-			background-color: @warningBackground;
-			border-color: @warningBorder;
+			background-color: @background-color-warning--framed;
+			border: @border-warning;
 		}
 
 		&.mw-message--success {
-			background-color: @successBackground;
-			border-color: @successBorder;
+			background-color: @background-color-success--framed;
+			border: @border-success;
 		}
 	}
 

--- a/resources/components/base/Suggestion.vue
+++ b/resources/components/base/Suggestion.vue
@@ -1,8 +1,10 @@
 <template>
 	<div
 		class="mw-suggestion"
-		tabindex="0"
 		v-bind:class="classObject"
+		role="checkbox"
+		tabindex="0"
+		v-bind:aria-checked="confirmed ? 'true' : 'false'"
 		v-on:click="$emit( 'click' )"
 		v-on:keyup.enter="$emit( 'click' )"
 		v-on:keyup.space="$emit( 'click' )"
@@ -21,6 +23,7 @@
 <script>
 var Icon = require( './Icon.vue' );
 
+// @vue/component
 module.exports = {
 	name: 'Suggestion',
 
@@ -57,13 +60,13 @@ module.exports = {
 
 <style lang="less">
 @import 'mediawiki.mixins';
-@import '../../style-variables.less';
+@import '../../../lib/wikimedia-ui-base.less';
 
 .mw-suggestion {
 	.transition( color @transition-duration-base );
-	background-color: @base90;
-	border: @suggestion-border-width solid @base50;
-	color: @base10;
+	background-color: @background-color-framed;
+	border: @border-base;
+	color: @color-base;
 	cursor: pointer;
 	margin: 0 4px 4px 0;
 	padding: 4px 1.25em;
@@ -72,12 +75,12 @@ module.exports = {
 
 	&:hover,
 	&:focus {
-		color: @base0;
+		color: @color-base--emphasized;
 	}
 
 	&:focus {
-		border-color: @accent30;
-		box-shadow: inset 0 0 0 1px @accent30;
+		border-color: @color-primary--active;
+		box-shadow: inset 0 0 0 1px @color-primary--active;
 		outline: 0;
 	}
 
@@ -99,9 +102,9 @@ module.exports = {
 	}
 
 	&--confirmed {
-		background-color: @accent90;
-		border-color: @accent30;
-		color: @base0;
+		background-color: @background-color-primary;
+		border-color: @color-primary--active;
+		color: @color-base--emphasized;
 		position: relative;
 
 		.mw-suggestion__label {

--- a/resources/components/base/Tabs.vue
+++ b/resources/components/base/Tabs.vue
@@ -128,17 +128,17 @@ module.exports = {
 
 <style lang="less">
 @import 'mediawiki.mixins';
-@import '../../style-variables.less';
+@import '../../../lib/wikimedia-ui-base.less';
 
 // stylelint-disable selector-class-pattern
 
 .mw-tabs {
 	&__header {
 		.flex-display();
-		.box-shadow( inset 0 -1px 0 0 @base50 );
+		.box-shadow( inset 0 -1px 0 0 @border-color-base );
 
 		&__item {
-			color: @base30;
+			color: @color-base--subtle;
 			cursor: pointer;
 			font-weight: bold;
 			margin: 6px 6px 0 0;
@@ -147,22 +147,22 @@ module.exports = {
 
 			&:hover,
 			&.is-active {
-				color: @progressive;
-				.box-shadow( inset 0 -2px 0 0 @progressive );
+				color: @color-primary;
+				.box-shadow( inset 0 -2px 0 0 @color-primary );
 			}
 
 			&:hover {
-				color: @progressive-hover;
-				.box-shadow( inset 0 -2px 0 0 @progressive-hover );
+				color: @color-primary--hover;
+				.box-shadow( inset 0 -2px 0 0 @color-primary--hover );
 			}
 
 			&.is-disabled {
-				color: @base50;
+				color: @color-base--disabled;
 				cursor: not-allowed;
 
 				&:hover,
 				&.is-active {
-					color: @base50;
+					color: @color-base--disabled;
 					box-shadow: unset;
 				}
 			}

--- a/resources/components/base/ToastNotification.vue
+++ b/resources/components/base/ToastNotification.vue
@@ -31,7 +31,7 @@
  * and process the notification. Message content should be as concise as
  * possible.
  *
- * Specifitying notification type provides helpful information to screen readers.
+ * Specifying notification type provides helpful information to screen readers.
  * Type can be one of "success" or "error".
  */
 // @vue/component
@@ -62,10 +62,10 @@ module.exports = {
 		 * duration, then hide the toast, which kicks off leave transitions.
 		 */
 		onAppear: function () {
-			var self = this;
-			setTimeout( function () {
-				self.show = false;
-			}, this.duration * 1000 );
+			var hideToast = function () {
+				this.show = false;
+			};
+			setTimeout( hideToast.bind( this ), this.duration * 1000 );
 		},
 		/**
 		 * After the leave transitions finish, remove the toast and wrapper.
@@ -83,7 +83,7 @@ module.exports = {
 
 <style lang="less">
 @import 'mediawiki.mixins';
-@import '../../style-variables.less';
+@import '../../../lib/wikimedia-ui-base.less';
 
 .mw-toast {
 	// Center the toast within the parent container.
@@ -92,16 +92,18 @@ module.exports = {
 }
 
 .mw-toast__notification {
-	background-color: @base10;
-	border-radius: @outer-border-radius;
+	background-color: @color-base;
+	border-radius: @border-radius-base * 4;
 	bottom: 5vh;
-	color: @base100;
+	color: @color-base--inverted;
 	display: inline-block;
 	margin: 0;
 	padding: 8px 32px;
 	position: fixed;
 	text-align: center;
 	width: 95%;
+	// This is debatable.
+	z-index: 4;
 
 	@media screen and ( min-width: @width-breakpoint-tablet ) {
 		width: auto;

--- a/resources/style-variables.less
+++ b/resources/style-variables.less
@@ -18,20 +18,6 @@
 @base90: @wmui-color-base90;
 @base100: @wmui-color-base100;
 @base10-hover: #444;
-@progressive: #36c;
-@progressive-hover: #447ff5;
-@destructive: #d33;
-@destructive-hover: #ff4242;
-
-// Messages
-@errorBackground: #fee7e6;
-@errorColor: @destructive;
-@errorBorder: @errorColor;
-@warningBackground: #fef6e7;
-@warningBorder: #fc3;
-@successBackground: #d5fdf4;
-@successColor: #14866d;
-@successBorder: @successColor;
 
 // Accent
 @accent30: @wmui-color-accent30;
@@ -41,7 +27,6 @@
 // ---------------------------------------------------------
 @wbmad-max-width: 60em;
 @outer-border-radius: 8px;
-@suggestion-border-width: 1px;
 @wbmad-spinner-size: 12px;
 
 // Mixins


### PR DESCRIPTION
This PR is a bunch of cleanup of base components:

- Remove all references to extension-specific variables and use the WMUI base variables instead
- Make sure we're not setting any default values for boolean props
- Remove the *last* self = this
- Add some accessibility stuff to Suggestion