### PR TITLE
Fix bug when toggling a suggestion when a non-displaying suggestion is present

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -202,6 +202,15 @@
 		"remoteExtPath": "MachineVision/resources"
 	},
 	"ResourceModules": {
+		"ext.MachineVision.polyfill": {
+			"scripts": [
+				"polyfills/Array.prototype.find.js"
+			],
+			"targets": [
+				"mobile",
+				"desktop"
+			]
+		},
 		"ext.MachineVision.init": {
 			"styles": [
 				"init.css",
@@ -261,6 +270,7 @@
 			"styles": [],
 			"dependencies": [
 				"ext.MachineVision.config",
+				"ext.MachineVision.polyfill",
 				"ext.eventLogging",
 				"oojs",
 				"oojs-ui-core",

--- a/resources/polyfills/Array.prototype.find.js
+++ b/resources/polyfills/Array.prototype.find.js
@@ -1,0 +1,48 @@
+// https://tc39.github.io/ecma262/#sec-array.prototype.find
+/* eslint-disable */
+
+if ( !Array.prototype.find ) {
+	Object.defineProperty( Array.prototype, 'find', {
+		value: function ( predicate ) {
+			// 1. Let O be ? ToObject(this value).
+			if ( this == null ) {
+				throw TypeError( '"this" is null or not defined' );
+			}
+
+			var o = Object( this );
+
+			// 2. Let len be ? ToLength(? Get(O, "length")).
+			var len = o.length >>> 0;
+
+			// 3. If IsCallable(predicate) is false, throw a TypeError exception.
+			if ( typeof predicate !== 'function' ) {
+				throw TypeError( 'predicate must be a function' );
+			}
+
+			// 4. If thisArg was supplied, let T be thisArg; else let T be undefined.
+			var thisArg = arguments[ 1 ];
+
+			// 5. Let k be 0.
+			var k = 0;
+
+			// 6. Repeat, while k < len
+			while ( k < len ) {
+				// a. Let Pk be ! ToString(k).
+				// b. Let kValue be ? Get(O, Pk).
+				// c. Let testResult be ToBoolean(? Call(predicate, T, « kValue, k, O »)).
+				// d. If testResult is true, return kValue.
+				var kValue = o[ k ];
+				if ( predicate.call( thisArg, kValue, k, o ) ) {
+					return kValue;
+				}
+				// e. Increase k by 1.
+				k++;
+			}
+
+			// 7. Return undefined.
+			return undefined;
+		},
+		configurable: true,
+		writable: true
+	});
+}

--- a/resources/store/actions.js
+++ b/resources/store/actions.js
@@ -121,19 +121,11 @@ module.exports = {
 	},
 
 	/**
-	 * Find a given tag among the current image suggestions and commit the
-	 * toggleSuggestion mutation to flip its state. Do nothing if tag is
-	 * not found.
-	 *
 	 * @param {Object} context
 	 * @param {Object} tag
 	 */
 	toggleTagConfirmation: function ( context, tag ) {
-		var tagIndex = context.getters.currentImageSuggestions.indexOf( tag );
-
-		if ( tagIndex >= 0 ) {
-			context.commit( 'toggleSuggestion', tagIndex );
-		}
+		context.commit( 'toggleSuggestion', tag );
 	},
 
 	/**

--- a/resources/store/mutations.js
+++ b/resources/store/mutations.js
@@ -74,11 +74,15 @@ module.exports = {
 	 * Toggle the confirmation state of a single suggestion of an image
 	 *
 	 * @param {Object} state
-	 * @param {integer} index
+	 * @param {Object} suggestion
+	 * @param {string} suggestion.text
 	 */
-	toggleSuggestion: function ( state, index ) {
+	toggleSuggestion: function ( state, suggestion ) {
 		var currentImage = state.images[ state.currentTab ][ 0 ],
-			selected = currentImage.suggestions[ index ];
+			// eslint-disable-next-line no-restricted-syntax
+			selected = currentImage.suggestions.find( function ( s ) {
+				return s.text === suggestion.text;
+			} );
 
 		selected.confirmed = !selected.confirmed;
 	},

--- a/resources/store/mutations.js
+++ b/resources/store/mutations.js
@@ -75,13 +75,13 @@ module.exports = {
 	 *
 	 * @param {Object} state
 	 * @param {Object} suggestion
-	 * @param {string} suggestion.text
+	 * @param {string} suggestion.wikidataId
 	 */
 	toggleSuggestion: function ( state, suggestion ) {
 		var currentImage = state.images[ state.currentTab ][ 0 ],
 			// eslint-disable-next-line no-restricted-syntax
 			selected = currentImage.suggestions.find( function ( s ) {
-				return s.text === suggestion.text;
+				return s.wikidataId === suggestion.wikidataId;
 			} );
 
 		selected.confirmed = !selected.confirmed;

--- a/tests/jest/actions.test.js
+++ b/tests/jest/actions.test.js
@@ -142,7 +142,7 @@ describe( 'getters', () => {
 	} );
 
 	describe( 'toggleTagConfirmation', () => {
-		it( 'Commits a toggleSuggestion mutation with the tag index as an argument', () => {
+		it( 'Commits a toggleSuggestion mutation with the tag as an argument', () => {
 			var suggestions = fixtures[ 0 ].suggestions,
 				tagIndex = 1,
 				tag = suggestions[ tagIndex ];
@@ -152,7 +152,7 @@ describe( 'getters', () => {
 			} );
 
 			actions.toggleTagConfirmation( context, tag );
-			expect( context.commit ).toHaveBeenCalledWith( 'toggleSuggestion', tagIndex );
+			expect( context.commit ).toHaveBeenCalledWith( 'toggleSuggestion', tag );
 		} );
 	} );
 

--- a/tests/jest/mutations.test.js
+++ b/tests/jest/mutations.test.js
@@ -124,14 +124,15 @@ describe( 'mutations', () => {
 	} );
 
 	describe( 'toggleSuggestion', () => {
-		it( 'finds a suggestion of the first image in the active tab based on index and toggles its state', () => {
+		it( 'finds a suggestion of the first image in the active tab and toggles its state', () => {
 			var image = fixtures[ 0 ],
-				suggestions = image.suggestions;
+				suggestions = image.suggestions,
+				suggestionToToggle = suggestions[ 0 ];
 
 			state.images.popular = [ image ];
-			expect( state.images.popular[ 0 ].suggestions[ 0 ].confirmed ).toBe( false );
+			expect( suggestionToToggle.confirmed ).toBe( false );
 
-			mutations.toggleSuggestion( state, 0 );
+			mutations.toggleSuggestion( state, suggestionToToggle );
 			expect( state.images.popular[ 0 ].suggestions[ 0 ].confirmed ).toBe( true );
 			expect( state.images.popular[ 0 ].suggestions[ 0 ].wikidataId ).toEqual( suggestions[ 0 ].wikidataId );
 		} );


### PR DESCRIPTION
It is possible that one or more suggestions for a given image cannot be
displayed to the user (because a label does not exist in their language, or a
wikidata item has moved/been deleted/etc.). When this happens we do not show
the suggestion to the user but it is still included in the original suggestions
array (and needs to be, for because of how we store reviewed state of labels in
the DB).

The problem is that we were mutating the suggestion "confirmed" state in Vuex
after locating the desired suggestion object using indexOf(). We were doing this
because Array.prototype.find() is not supported in IE. Unfortunatley the index
of a label in the displayed suggestions (the ones which we can show to the user)
may not always match the "real" index of the label in Vuex state if any
non-displayable suggestions are present.

In real-world terms, this leads to a confusing bug where the user clicks on
a label only to see the label *next to* whatever they clicked on get toggled.

This whole issue can be bypassed by simply using Array.prototype.find() to
locate the desired suggestion based on label text instead of array index.

In order to do this, a polyfill has been added for IE (kept in a separate
resource module called "ext.MachineVision.polyfill"). Tests have also been
updated.

Change-Id: I2835523666e0d3a1602fa2c6b93d957db295d7e9