### PR TITLE
Centralized messaging

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -45,7 +45,7 @@
 	"machinevision-cta-cta": "Tag popular images",
 	"machinevision-no-uploads-cta-heading": "You have no images for review",
 	"machinevision-no-uploads-cta-text": "Please upload new images so our tool can analyze them and suggest appropriate tags. If you've already uploaded images and don't see them here, those images may be still under review and you can check back later. You can also make popular images from other users easier to find by tagging them.",
-	"machinevision-generic-no-images-heading": "There are no more images available to tag at this time.",
+	"machinevision-generic-no-images-heading": "There are no images available to tag at this time.",
 	"machinevision-generic-no-images-text": "Please check back later to tag more images.",
 	"machinevision-javascript-required": "This feature is not supported in your web browser.",
 	"machinevision-categories-label": "Categories:",

--- a/resources/components/App.vue
+++ b/resources/components/App.vue
@@ -3,10 +3,10 @@
 		<div class="wbmad-suggested-tags-page">
 			<template v-if="showToasts">
 				<mw-toast-notification
-					v-for="toast in toastNotifications"
-					v-bind:key="toast.key"
-					v-bind:type="toast.type"
-					v-bind:duration="toast.duration"
+					v-for="message in imageMessages"
+					v-bind:key="message.key"
+					v-bind:type="message.type"
+					v-bind:duration="message.duration"
 					v-on:leave="onToastLeave"
 				>
 					<p>{{ $i18n( toast.messageKey ) }}</p>
@@ -105,7 +105,7 @@ module.exports = {
 
 	computed: $.extend( {}, mapState( [
 		'currentTab',
-		'toastNotifications'
+		'imageMessages'
 	] ), mapGetters( [
 		'isAuthenticated',
 		'isAutoconfirmed',
@@ -140,14 +140,14 @@ module.exports = {
 		},
 
 		showToasts: function () {
-			return this.toastNotifications && this.toastNotifications.length > 0;
+			return this.imageMessages && this.imageMessages.length > 0;
 		}
 	} ),
 
 	methods: $.extend( {}, mapActions( [
 		'updateCurrentTab',
 		'getImages',
-		'hideToastNotification'
+		'hideImageMessage'
 	] ), {
 		/**
 		 * Watch the tab change events emitted by the <Tabs> component
@@ -166,7 +166,7 @@ module.exports = {
 		 * @param {string} toastKey
 		 */
 		onToastLeave: function ( toastKey ) {
-			this.hideToastNotification( toastKey );
+			this.hideImageMessage( toastKey );
 		},
 
 		/**

--- a/resources/components/App.vue
+++ b/resources/components/App.vue
@@ -1,25 +1,17 @@
 <template>
 	<wbmad-fade-in>
 		<div class="wbmad-suggested-tags-page">
-			<toast-notification
-				v-if="publishError"
-				v-bind:key="'publishError-' + Date.now()"
-				type="error"
-				duration="8"
-				v-on:leave="onToastLeave"
-			>
-				<p v-i18n-html:machinevision-publish-error-message />
-			</toast-notification>
-
-			<toast-notification
-				v-if="publishSuccess"
-				v-bind:key="'publishSuccess-' + Date.now()"
-				type="success"
-				v-bind:duration="4"
-				v-on:leave="onToastLeave"
-			>
-				<p v-i18n-html:machinevision-success-message />
-			</toast-notification>
+			<template v-if="showToasts">
+				<mw-toast-notification
+					v-for="toast in toastNotifications"
+					v-bind:key="toast.key"
+					v-bind:type="toast.type"
+					v-bind:duration="toast.duration"
+					v-on:leave="onToastLeave"
+				>
+					<p>{{ $i18n( toast.messageKey ) }}</p>
+				</mw-toast-notification>
+			</template>
 
 			<!-- Tabs container -->
 			<template v-if="showTabs">
@@ -105,7 +97,7 @@ module.exports = {
 	components: {
 		tabs: Tabs,
 		tab: Tab,
-		'toast-notification': ToastNotification,
+		'mw-toast-notification': ToastNotification,
 		'card-stack': CardStack,
 		'personal-uploads-count': PersonalUploadsCount,
 		'wbmad-fade-in': FadeIn
@@ -113,7 +105,7 @@ module.exports = {
 
 	computed: $.extend( {}, mapState( [
 		'currentTab',
-		'publishStatus'
+		'toastNotifications'
 	] ), mapGetters( [
 		'isAuthenticated',
 		'isAutoconfirmed',
@@ -147,19 +139,15 @@ module.exports = {
 			return this.$i18n( 'machinevision-machineaidedtagging-user-tab' ).text();
 		},
 
-		publishSuccess: function () {
-			return this.publishStatus === 'success';
-		},
-
-		publishError: function () {
-			return this.publishStatus === 'error';
+		showToasts: function () {
+			return this.toastNotifications && this.toastNotifications.length > 0;
 		}
 	} ),
 
 	methods: $.extend( {}, mapActions( [
 		'updateCurrentTab',
 		'getImages',
-		'updatePublishStatus'
+		'hideToastNotification'
 	] ), {
 		/**
 		 * Watch the tab change events emitted by the <Tabs> component
@@ -172,8 +160,14 @@ module.exports = {
 			this.updateCurrentTab( tab.name );
 		},
 
-		onToastLeave: function () {
-			this.updatePublishStatus( null );
+		/**
+		 * Hide a toast notification that has past its display duration.
+		 *
+		 * @param {string} toastKey
+		 */
+		onToastLeave: function ( toastKey ) {
+			console.log('on toast leave');
+			this.hideToastNotification( toastKey );
 		},
 
 		/**

--- a/resources/components/App.vue
+++ b/resources/components/App.vue
@@ -166,7 +166,6 @@ module.exports = {
 		 * @param {string} toastKey
 		 */
 		onToastLeave: function ( toastKey ) {
-			console.log('on toast leave');
 			this.hideToastNotification( toastKey );
 		},
 

--- a/resources/components/CardStack.vue
+++ b/resources/components/CardStack.vue
@@ -73,7 +73,7 @@ module.exports = {
 
 	computed: $.extend( {}, mapState( [
 		'currentTab',
-		'pending',
+		'fetchPending',
 		'images',
 		'userStats',
 		'cardStackMessage'
@@ -92,7 +92,7 @@ module.exports = {
 		 * @return {bool}
 		 */
 		isPending: function () {
-			return this.pending[ this.queue ];
+			return this.fetchPending[ this.queue ];
 		},
 
 		/**

--- a/resources/components/CardStack.vue
+++ b/resources/components/CardStack.vue
@@ -2,12 +2,9 @@
 	<div class="wbmad-suggested-tags-cardstack">
 		<wbmad-cardstack-placeholder v-if="isPending" />
 
-		<wbmad-fade-in v-else-if="cardStackMessage">
-			<mw-message
-				class="wbmad-cardstack-message"
-				v-bind:type="cardStackMessage.type"
-			>
-				<p v-i18n-html="cardStackMessage.messageKey" />
+		<wbmad-fade-in v-else-if="isError">
+			<mw-message class="wbmad-cardstack-message" type="error">
+				<p v-i18n-html:machinevision-failure-message />
 			</mw-message>
 		</wbmad-fade-in>
 
@@ -74,9 +71,9 @@ module.exports = {
 	computed: $.extend( {}, mapState( [
 		'currentTab',
 		'fetchPending',
+		'fetchError',
 		'images',
-		'userStats',
-		'cardStackMessage'
+		'userStats'
 	] ), mapGetters( [
 		'currentImage'
 	] ), {
@@ -93,6 +90,14 @@ module.exports = {
 		 */
 		isPending: function () {
 			return this.fetchPending[ this.queue ];
+		},
+
+		/**
+		 * Fetch error state is queue-specific
+		 * @return {bool}
+		 */
+		isError: function () {
+			return this.fetchError[ this.queue ];
 		},
 
 		/**
@@ -119,7 +124,7 @@ module.exports = {
 		 * @return {boolean}
 		 */
 		userHasLabeledUploads: function () {
-			return this.userStats.total > 0;
+			return this.userStats.total ? this.userStats.total > 0 : false;
 		},
 
 		/**

--- a/resources/components/CardStack.vue
+++ b/resources/components/CardStack.vue
@@ -2,6 +2,15 @@
 	<div class="wbmad-suggested-tags-cardstack">
 		<wbmad-cardstack-placeholder v-if="isPending" />
 
+		<wbmad-fade-in v-else-if="cardStackMessage">
+			<mw-message
+				class="wbmad-cardstack-message"
+				v-bind:type="cardStackMessage.type"
+			>
+				<p v-i18n-html="cardStackMessage.messageKey" />
+			</mw-message>
+		</wbmad-fade-in>
+
 		<transition v-else-if="shouldDisplayImage"
 			name="wbmad-fade"
 			appear
@@ -38,8 +47,10 @@ var mapState = require( 'vuex' ).mapState,
 	mapGetters = require( 'vuex' ).mapGetters,
 	mapActions = require( 'vuex' ).mapActions,
 	CardStackPlaceholder = require( './CardStackPlaceholder.vue' ),
+	FadeIn = require( './FadeIn.vue' ),
 	ImageCard = require( './ImageCard.vue' ),
-	UserImage = require( './UserMessage.vue' );
+	UserImage = require( './UserMessage.vue' ),
+	Message = require( './base/Message.vue' );
 
 // @vue/component
 module.exports = {
@@ -47,8 +58,10 @@ module.exports = {
 
 	components: {
 		'wbmad-cardstack-placeholder': CardStackPlaceholder,
+		'wbmad-fade-in': FadeIn,
 		'wbmad-image-card': ImageCard,
-		'wbmad-user-message': UserImage
+		'wbmad-user-message': UserImage,
+		'mw-message': Message
 	},
 
 	props: {
@@ -62,7 +75,8 @@ module.exports = {
 		'currentTab',
 		'pending',
 		'images',
-		'userStats'
+		'userStats',
+		'cardStackMessage'
 	] ), mapGetters( [
 		'currentImage'
 	] ), {
@@ -175,6 +189,15 @@ module.exports = {
 .wbmad-user-cta--generic-no-images {
 	.wbmad-user-message-icon {
 		background-image: url( ../icons/empty-state-icon-no-uploads.svg );
+	}
+}
+
+.wbmad-cardstack-message {
+	// Avoid a major layout jump for items below cardstack.
+	margin-bottom: 150px;
+
+	p {
+		margin: 0;
 	}
 }
 

--- a/resources/components/ImageCard.vue
+++ b/resources/components/ImageCard.vue
@@ -98,7 +98,7 @@ module.exports = {
 		'currentImage',
 		'currentImageSuggestions'
 	] ), mapState( [
-		'publishStatus'
+		'publishPending'
 	] ), {
 		/**
 		 * @return {string}
@@ -159,13 +159,6 @@ module.exports = {
 			return this.currentImageSuggestions.filter( function ( suggestion ) {
 				return suggestion.confirmed;
 			} );
-		},
-
-		/**
-		 * @return {boolean}
-		 */
-		publishPending: function () {
-			return this.publishStatus === 'pending';
 		},
 
 		/**

--- a/resources/store/actions.js
+++ b/resources/store/actions.js
@@ -58,7 +58,7 @@ module.exports = {
 			query.ilstate = 'unreviewed|withheld';
 		}
 
-		context.commit( 'setPending', {
+		context.commit( 'setFetchPending', {
 			queue: queue,
 			pending: true
 		} );
@@ -118,7 +118,7 @@ module.exports = {
 			} );
 		} ).always( function () {
 			// Remove the pending state
-			context.commit( 'setPending', {
+			context.commit( 'setFetchPending', {
 				queue: queue,
 				pending: false
 			} );

--- a/resources/store/actions.js
+++ b/resources/store/actions.js
@@ -62,6 +62,7 @@ module.exports = {
 			queue: queue,
 			pending: true
 		} );
+		context.commit( 'hideCardStackMessage' );
 
 		// Request images from the API
 		return api.get( query ).then( function ( res ) {
@@ -109,14 +110,18 @@ module.exports = {
 			} catch ( e ) {
 				// Use default state values.
 			}
-
+		} ).catch( function ( /* errorCode, error */ ) {
+			// Show a generic error message if fetch fails.
+			context.dispatch( 'showCardStackMessage', {
+				messageKey: 'machinevision-failure-message',
+				type: 'error'
+			} );
+		} ).always( function () {
 			// Remove the pending state
 			context.commit( 'setPending', {
 				queue: queue,
 				pending: false
 			} );
-		} ).catch( function ( /* error */ ) {
-			// @TODO error handling logic
 		} );
 	},
 
@@ -264,6 +269,15 @@ module.exports = {
 		context.commit( 'setPublishPending', publishPendingStatus );
 	},
 
+	addCustomTag: function ( context, tag ) {
+		var suggestion = new MvSuggestion( tag.text, tag.wikidataId );
+
+		suggestion.custom = true; // Set this so we can filter out user-added suggestions on submit
+		suggestion.confirmed = true;
+
+		context.commit( 'addSuggestionToCurrentImage', suggestion );
+	},
+
 	/**
 	 * Display a toast notification.
 	 *
@@ -288,12 +302,24 @@ module.exports = {
 		context.commit( 'removeToastNotification', toastKey );
 	},
 
-	addCustomTag: function ( context, tag ) {
-		var suggestion = new MvSuggestion( tag.text, tag.wikidataId );
+	/**
+	 * Display a standard message, to be shown in the CardStack component.
+	 *
+	 * @param {Object} context
+	 * @param {Object} messageData
+	 * @param {string} messageData.messageKey The i18n message key to display
+	 * @param {string} messageData.type The message type (success, error, etc.)
+	 */
+	showCardStackMessage: function ( context, messageData ) {
+		context.commit( 'setCardStackMessage', messageData );
+	},
 
-		suggestion.custom = true; // Set this so we can filter out user-added suggestions on submit
-		suggestion.confirmed = true;
-
-		context.commit( 'addSuggestionToCurrentImage', suggestion );
+	/**
+	 * Hide CardStack message.
+	 *
+	 * @param {Object} context
+	 */
+	hideCardStackMessage: function ( context ) {
+		context.commit( 'removeCardStackMessage' );
 	}
 };

--- a/resources/store/mutations.js
+++ b/resources/store/mutations.js
@@ -95,13 +95,13 @@ module.exports = {
 	},
 
 	/**
-	 * Set the publish status (to success, error, pending or null).
+	 * Set publish pending status.
 	 *
 	 * @param {Object} state
-	 * @param {string|null} publishStatus
+	 * @param {boolean} publishPendingStatus
 	 */
-	setPublishStatus: function ( state, publishStatus ) {
-		state.publishStatus = publishStatus;
+	setPublishPending: function ( state, publishPendingStatus ) {
+		state.publishPending = publishPendingStatus;
 	},
 
 	setUserStats: function ( state, payload ) {
@@ -110,6 +110,7 @@ module.exports = {
 
 	/**
 	 * Set the initial count of user's unreviewed images
+	 *
 	 * @param {Object} state
 	 * @param {number} count
 	 */
@@ -122,5 +123,30 @@ module.exports = {
 	 */
 	decrementUnreviewedCount: function ( state ) {
 		state.unreviewedCount--;
+	},
+
+	/**
+	 * Add a new toast notification to the store.
+	 *
+	 * @param {Object} state
+	 * @param {Object} toastData
+	 * @param {string} toastData.key The i18n message key to display
+	 * @param {string} toastData.type The message type (success, error, etc.)
+	 * @param {number} toastData.duration Display duration in seconds
+	 */
+	setToastNotification: function ( state, toastData ) {
+		state.toastNotifications = state.toastNotifications.concat( [ toastData ] );
+	},
+
+	/**
+	 * Remove a toast notification from the store.
+	 *
+	 * @param {Object} state
+	 * @param {string} toastKey Unique key of the toast to be hidden
+	 */
+	removeToastNotification: function ( state, toastKey ) {
+		state.toastNotifications = state.toastNotifications.filter( function ( toast ) {
+			return toast.key !== toastKey;
+		} );
 	}
 };

--- a/resources/store/mutations.js
+++ b/resources/store/mutations.js
@@ -130,7 +130,8 @@ module.exports = {
 	 *
 	 * @param {Object} state
 	 * @param {Object} toastData
-	 * @param {string} toastData.key The i18n message key to display
+	 * @param {string} toastData.key Unique key for the toast component
+	 * @param {string} toastData.messageKey The i18n message key to display
 	 * @param {string} toastData.type The message type (success, error, etc.)
 	 * @param {number} toastData.duration Display duration in seconds
 	 */
@@ -148,5 +149,26 @@ module.exports = {
 		state.toastNotifications = state.toastNotifications.filter( function ( toast ) {
 			return toast.key !== toastKey;
 		} );
+	},
+
+	/**
+	 * Add a CardStack message to the store.
+	 *
+	 * @param {Object} state
+	 * @param {Object} messageData
+	 * @param {string} messageData.messageKey The i18n message key to display
+	 * @param {string} messageData.type The message type (success, error, etc.)
+	 */
+	setCardStackMessage: function ( state, messageData ) {
+		state.cardStackMessage = messageData;
+	},
+
+	/**
+	 * Remove CardStack message from the store.
+	 *
+	 * @param {Object} state
+	 */
+	removeCardStackMessage: function ( state ) {
+		state.cardStackMessage = null;
 	}
 };

--- a/resources/store/mutations.js
+++ b/resources/store/mutations.js
@@ -16,19 +16,19 @@ module.exports = {
 	},
 
 	/**
-	 * Sets the pending state
+	 * Sets the fetch pending state
 	 *
 	 * @param {Object} state
 	 * @param {Object} payload
 	 * @param {bool} payload.pending
 	 * @param {string} [payload.queue]
 	 */
-	setPending: function ( state, payload ) {
+	setFetchPending: function ( state, payload ) {
 		if ( payload.queue ) {
 			ensureTabExists( state, payload.queue );
-			state.pending[ payload.queue ] = !!payload.pending;
+			state.fetchPending[ payload.queue ] = !!payload.pending;
 		} else {
-			state.pending[ state.currentTab ] = !!payload.pending;
+			state.fetchPending[ state.currentTab ] = !!payload.pending;
 		}
 
 	},
@@ -74,7 +74,7 @@ module.exports = {
 	 */
 	clearImages: function ( state ) {
 		state.images[ state.currentTab ] = [];
-		state.pending[ state.currentTab ] = true;
+		state.fetchPending[ state.currentTab ] = true;
 	},
 
 	/**

--- a/resources/store/mutations.js
+++ b/resources/store/mutations.js
@@ -30,7 +30,23 @@ module.exports = {
 		} else {
 			state.fetchPending[ state.currentTab ] = !!payload.pending;
 		}
+	},
 
+	/**
+	 * Sets the fetch error state
+	 *
+	 * @param {Object} state
+	 * @param {Object} payload
+	 * @param {bool} payload.error
+	 * @param {string} [payload.queue]
+	 */
+	setFetchError: function ( state, payload ) {
+		if ( payload.queue ) {
+			ensureTabExists( state, payload.queue );
+			state.fetchError[ payload.queue ] = !!payload.error;
+		} else {
+			state.fetchError[ state.currentTab ] = !!payload.error;
+		}
 	},
 
 	/**
@@ -126,49 +142,28 @@ module.exports = {
 	},
 
 	/**
-	 * Add a new toast notification to the store.
-	 *
-	 * @param {Object} state
-	 * @param {Object} toastData
-	 * @param {string} toastData.key Unique key for the toast component
-	 * @param {string} toastData.messageKey The i18n message key to display
-	 * @param {string} toastData.type The message type (success, error, etc.)
-	 * @param {number} toastData.duration Display duration in seconds
-	 */
-	setToastNotification: function ( state, toastData ) {
-		state.toastNotifications = state.toastNotifications.concat( [ toastData ] );
-	},
-
-	/**
-	 * Remove a toast notification from the store.
-	 *
-	 * @param {Object} state
-	 * @param {string} toastKey Unique key of the toast to be hidden
-	 */
-	removeToastNotification: function ( state, toastKey ) {
-		state.toastNotifications = state.toastNotifications.filter( function ( toast ) {
-			return toast.key !== toastKey;
-		} );
-	},
-
-	/**
-	 * Add a CardStack message to the store.
+	 * Add a new image message to the store.
 	 *
 	 * @param {Object} state
 	 * @param {Object} messageData
+	 * @param {string} messageData.key Unique key for the toast component
 	 * @param {string} messageData.messageKey The i18n message key to display
 	 * @param {string} messageData.type The message type (success, error, etc.)
+	 * @param {number} messageData.duration Display duration in seconds
 	 */
-	setCardStackMessage: function ( state, messageData ) {
-		state.cardStackMessage = messageData;
+	setImageMessage: function ( state, messageData ) {
+		state.imageMessages = state.imageMessages.concat( [ messageData ] );
 	},
 
 	/**
-	 * Remove CardStack message from the store.
+	 * Remove an image message from the store.
 	 *
 	 * @param {Object} state
+	 * @param {string} key Unique key of the Vue component to be hidden
 	 */
-	removeCardStackMessage: function ( state ) {
-		state.cardStackMessage = null;
+	removeImageMessage: function ( state, key ) {
+		state.imageMessages = state.imageMessages.filter( function ( message ) {
+			return message.key !== key;
+		} );
 	}
 };

--- a/resources/store/state.js
+++ b/resources/store/state.js
@@ -8,14 +8,14 @@ module.exports = {
 		user: []
 	},
 
-	pending: {
+	fetchPending: {
 		popular: false,
 		user: false
 	},
 
-	unreviewedCount: 0,
-
 	publishPending: false,
+
+	unreviewedCount: 0,
 
 	userStats: {},
 

--- a/resources/store/state.js
+++ b/resources/store/state.js
@@ -13,13 +13,16 @@ module.exports = {
 		user: false
 	},
 
+	fetchError: {
+		popular: false,
+		user: false
+	},
+
 	publishPending: false,
 
 	unreviewedCount: 0,
 
 	userStats: {},
 
-	toastNotifications: [],
-
-	cardStackMessage: null
+	imageMessages: []
 };

--- a/resources/store/state.js
+++ b/resources/store/state.js
@@ -19,5 +19,7 @@ module.exports = {
 
 	userStats: {},
 
-	toastNotifications: []
+	toastNotifications: [],
+
+	cardStackMessage: null
 };

--- a/resources/store/state.js
+++ b/resources/store/state.js
@@ -15,18 +15,9 @@ module.exports = {
 
 	unreviewedCount: 0,
 
-	/**
-	 * @TODO Currently four possible status states exist:
-	 * - "success"
-	 * - "error"
-	 * - "pending"
-	 * - null (default)
-	 *
-	 * It may be time to think about enforcing a consistent and constrained
-	 * list of states here and in the corresponding mutation, maybe by defining
-	 * publish states in an external object and importing them here
-	 */
-	publishStatus: null,
+	publishPending: false,
 
-	userStats: {}
+	userStats: {},
+
+	toastNotifications: []
 };

--- a/tests/jest/App.test.js
+++ b/tests/jest/App.test.js
@@ -23,7 +23,7 @@ describe( 'App', () => {
 				popular: [],
 				user: []
 			},
-			pending: {
+			fetchPending: {
 				popular: false,
 				user: false
 			},

--- a/tests/jest/App.test.js
+++ b/tests/jest/App.test.js
@@ -27,6 +27,10 @@ describe( 'App', () => {
 				popular: false,
 				user: false
 			},
+			fetchError: {
+				popular: false,
+				user: false
+			},
 			userStats: {
 				total: 20,
 				unreviewed: 10

--- a/tests/jest/CardStack.test.js
+++ b/tests/jest/CardStack.test.js
@@ -24,7 +24,7 @@ describe( 'CardStack', () => {
 				popular: imageData, // contains 4 images
 				user: []
 			},
-			pending: {
+			fetchPending: {
 				popular: false,
 				user: false
 			},

--- a/tests/jest/CardStack.test.js
+++ b/tests/jest/CardStack.test.js
@@ -28,6 +28,10 @@ describe( 'CardStack', () => {
 				popular: false,
 				user: false
 			},
+			fetchError: {
+				popular: false,
+				user: false
+			},
 			userStats: {
 				total: 20,
 				unreviewed: 10

--- a/tests/jest/actions.test.js
+++ b/tests/jest/actions.test.js
@@ -221,10 +221,15 @@ describe( 'getters', () => {
 		// For these tests, mockApi needs to return jQuery deferred objects
 		// rather than vanilla promises
 
-		it( 'updates publish status to "success" if requests are successful', done => {
+		it( 'shows success toast notification if requests are successful', done => {
 			var suggestions = fixtures[ 0 ].suggestions,
 				deferred = $.Deferred(),
-				promise = deferred.promise();
+				promise = deferred.promise(),
+				successToast = {
+					messageKey: 'machinevision-success-message',
+					type: 'success',
+					duration: 4
+				};
 
 			suggestions[ 0 ].confirmed = true;
 
@@ -245,14 +250,14 @@ describe( 'getters', () => {
 			actions.publishTags( context );
 
 			promise.always( () => {
-				expect( context.dispatch ).toHaveBeenCalledWith( 'updatePublishStatus', 'success' );
+				expect( context.dispatch ).toHaveBeenCalledWith( 'showToastNotification', successToast );
 				done();
 			} );
 
 			deferred.resolve( {} );
 		} );
 
-		it( 'updates publish status to error if requests fail', done => {
+		it( 'sets publishPending to false after successful request completes', done => {
 			var suggestions = fixtures[ 0 ].suggestions,
 				deferred = $.Deferred(),
 				promise = deferred.promise();
@@ -276,7 +281,74 @@ describe( 'getters', () => {
 			actions.publishTags( context );
 
 			promise.always( () => {
-				expect( context.dispatch ).toHaveBeenCalledWith( 'updatePublishStatus', 'error' );
+				expect( context.dispatch ).toHaveBeenCalledWith( 'updatePublishPending', false );
+				done();
+			} );
+
+			deferred.resolve( {} );
+		} );
+
+		it( 'shows error toast notification if requests fail', done => {
+			var suggestions = fixtures[ 0 ].suggestions,
+				deferred = $.Deferred(),
+				promise = deferred.promise(),
+				toast = {
+					messageKey: 'machinevision-publish-error-message',
+					type: 'error',
+					duration: 8
+				};
+
+			suggestions[ 0 ].confirmed = true;
+
+			mockApi.postWithToken.mockReturnValue( promise );
+
+			Object.defineProperty( context.getters, 'currentImageSuggestions', {
+				get: jest.fn().mockReturnValue( suggestions )
+			} );
+
+			Object.defineProperty( context.getters, 'currentImageTitle', {
+				get: jest.fn().mockReturnValue( 'Test' )
+			} );
+
+			Object.defineProperty( context.getters, 'currentImageNonDisplayableSuggestions', {
+				get: jest.fn().mockReturnValue( [] )
+			} );
+
+			actions.publishTags( context );
+
+			promise.always( () => {
+				expect( context.dispatch ).toHaveBeenCalledWith( 'showToastNotification', toast );
+				done();
+			} );
+
+			deferred.reject( {} );
+		} );
+
+		it( 'sets publishPending to false after failed request completes', done => {
+			var suggestions = fixtures[ 0 ].suggestions,
+				deferred = $.Deferred(),
+				promise = deferred.promise();
+
+			suggestions[ 0 ].confirmed = true;
+
+			mockApi.postWithToken.mockReturnValue( promise );
+
+			Object.defineProperty( context.getters, 'currentImageSuggestions', {
+				get: jest.fn().mockReturnValue( suggestions )
+			} );
+
+			Object.defineProperty( context.getters, 'currentImageTitle', {
+				get: jest.fn().mockReturnValue( 'Test' )
+			} );
+
+			Object.defineProperty( context.getters, 'currentImageNonDisplayableSuggestions', {
+				get: jest.fn().mockReturnValue( [] )
+			} );
+
+			actions.publishTags( context );
+
+			promise.always( () => {
+				expect( context.dispatch ).toHaveBeenCalledWith( 'updatePublishPending', false );
 				done();
 			} );
 
@@ -427,13 +499,13 @@ describe( 'getters', () => {
 		} );
 	} );
 
-	describe( 'updatePublishStatus', () => {
-		it( 'commits the setPublishStatus mutation with the payload as an argument', () => {
-			actions.updatePublishStatus( context, true );
-			expect( context.commit ).toHaveBeenCalledWith( 'setPublishStatus', true );
+	describe( 'updatePublishPending', () => {
+		it( 'commits the setPublishPending mutation with the payload as an argument', () => {
+			actions.updatePublishPending( context, true );
+			expect( context.commit ).toHaveBeenCalledWith( 'setPublishPending', true );
 
-			actions.updatePublishStatus( context, false );
-			expect( context.commit ).toHaveBeenCalledWith( 'setPublishStatus', false );
+			actions.updatePublishPending( context, false );
+			expect( context.commit ).toHaveBeenCalledWith( 'setPublishPending', false );
 		} );
 	} );
 } );

--- a/tests/jest/actions.test.js
+++ b/tests/jest/actions.test.js
@@ -85,14 +85,14 @@ describe( 'getters', () => {
 
 			context.state.currentTab = 'popular';
 			actions.getImages( context );
-			expect( context.commit ).toHaveBeenCalledWith( 'setPending', {
+			expect( context.commit ).toHaveBeenCalledWith( 'setFetchPending', {
 				queue: 'popular',
 				pending: true
 			} );
 
 			context.state.currentTab = 'user';
 			actions.getImages( context );
-			expect( context.commit ).toHaveBeenCalledWith( 'setPending', {
+			expect( context.commit ).toHaveBeenCalledWith( 'setFetchPending', {
 				queue: 'user',
 				pending: true
 			} );
@@ -106,7 +106,7 @@ describe( 'getters', () => {
 
 			context.state.currentTab = 'popular';
 			actions.getImages( context, { queue: 'user' } );
-			expect( context.commit ).toHaveBeenCalledWith( 'setPending', {
+			expect( context.commit ).toHaveBeenCalledWith( 'setFetchPending', {
 				queue: 'user',
 				pending: true
 			} );
@@ -138,7 +138,7 @@ describe( 'getters', () => {
 			mockApi.get.mockReturnValue( promise );
 
 			actions.getImages( context ).then( () => {
-				expect( context.commit ).toHaveBeenCalledWith( 'setPending', {
+				expect( context.commit ).toHaveBeenCalledWith( 'setFetchPending', {
 					queue: 'popular',
 					pending: false
 				} );
@@ -155,15 +155,15 @@ describe( 'getters', () => {
 
 			actions.getImages( context );
 
-			promise.always( () => {
-				// Error message should be added.
-				expect( context.commit ).toHaveBeenCalledWith( 'showCardStackMessage', {
+			promise.then( () => {
+				// We only care about errors here, so do nothing
+			} ).catch( () => {
+				expect( context.dispatch ).toHaveBeenCalledWith( 'showCardStackMessage', {
 					messageKey: 'machinevision-failure-message',
 					type: 'error'
 				} );
-
-				// Pending state should be removed.
-				expect( context.commit ).toHaveBeenCalledWith( 'setPending', {
+			} ).always( () => {
+				expect( context.commit ).toHaveBeenCalledWith( 'setFetchPending', {
 					queue: 'popular',
 					pending: false
 				} );

--- a/tests/jest/actions.test.js
+++ b/tests/jest/actions.test.js
@@ -158,9 +158,9 @@ describe( 'getters', () => {
 			promise.then( () => {
 				// We only care about errors here, so do nothing
 			} ).catch( () => {
-				expect( context.dispatch ).toHaveBeenCalledWith( 'showCardStackMessage', {
-					messageKey: 'machinevision-failure-message',
-					type: 'error'
+				expect( context.commit ).toHaveBeenCalledWith( 'setFetchError', {
+					queue: 'popular',
+					error: true
 				} );
 			} ).always( () => {
 				expect( context.commit ).toHaveBeenCalledWith( 'setFetchPending', {
@@ -299,7 +299,7 @@ describe( 'getters', () => {
 			actions.publishTags( context );
 
 			promise.always( () => {
-				expect( context.dispatch ).toHaveBeenCalledWith( 'showToastNotification', successToast );
+				expect( context.dispatch ).toHaveBeenCalledWith( 'showImageMessage', successToast );
 				done();
 			} );
 
@@ -366,7 +366,7 @@ describe( 'getters', () => {
 			actions.publishTags( context );
 
 			promise.always( () => {
-				expect( context.dispatch ).toHaveBeenCalledWith( 'showToastNotification', toast );
+				expect( context.dispatch ).toHaveBeenCalledWith( 'showImageMessage', toast );
 				done();
 			} );
 

--- a/tests/jest/getters.test.js
+++ b/tests/jest/getters.test.js
@@ -20,7 +20,7 @@ describe( 'getters', () => {
 			},
 
 			currentTab: 'popular',
-			publishStatus: null
+			publishPending: false
 		};
 
 		// Create a fresh copy of imageFixtures so any mutations made to the

--- a/tests/jest/getters.test.js
+++ b/tests/jest/getters.test.js
@@ -14,7 +14,7 @@ describe( 'getters', () => {
 				user: []
 			},
 
-			pending: {
+			fetchPending: {
 				popular: false,
 				user: false
 			},

--- a/tests/jest/mutations.test.js
+++ b/tests/jest/mutations.test.js
@@ -18,7 +18,7 @@ describe( 'mutations', () => {
 			},
 
 			currentTab: 'popular',
-			publishStatus: null
+			publishPending: false
 		};
 
 		// Create a fresh copy of imageFixtures so any mutations made to the
@@ -138,10 +138,10 @@ describe( 'mutations', () => {
 		} );
 	} );
 
-	describe( 'setPublishStatus', () => {
-		it( 'sets the publishStatus state to the specified value', () => {
-			mutations.setPublishStatus( state, 'error' );
-			expect( state.publishStatus ).toBe( 'error' );
+	describe( 'setPublishPending', () => {
+		it( 'sets the publishPending state to the specified value', () => {
+			mutations.setPublishPending( state, true );
+			expect( state.publishPending ).toBe( true );
 		} );
 	} );
 } );

--- a/tests/jest/mutations.test.js
+++ b/tests/jest/mutations.test.js
@@ -12,7 +12,7 @@ describe( 'mutations', () => {
 				user: []
 			},
 
-			pending: {
+			fetchPending: {
 				popular: false,
 				user: false
 			},
@@ -39,24 +39,24 @@ describe( 'mutations', () => {
 		} );
 	} );
 
-	describe( 'setPending', () => {
+	describe( 'setFetchPending', () => {
 		it( 'sets the pending state of the specified queue to the specified value', () => {
-			mutations.setPending( state, {
+			mutations.setFetchPending( state, {
 				queue: 'user',
 				pending: true
 			} );
 
-			expect( state.pending.user ).toBe( true );
+			expect( state.fetchPending.user ).toBe( true );
 		} );
 
 		it( 'sets the pending state of the current tab queue if no queue is provided', () => {
-			mutations.setPending( state, { pending: true } );
-			expect( state.pending.popular ).toBe( true );
+			mutations.setFetchPending( state, { pending: true } );
+			expect( state.fetchPending.popular ).toBe( true );
 		} );
 
 		it( 'throws an error if desired tab does not exist as a key in state.images', () => {
 			expect( () => {
-				mutations.setPending( state, {
+				mutations.setFetchPending( state, {
 					queue: 'foo',
 					pending: true
 				} );
@@ -119,7 +119,7 @@ describe( 'mutations', () => {
 		it( 'resets pending state of the current tab to true', () => {
 			state.images.popular = fixtures;
 			mutations.clearImages( state );
-			expect( state.pending.popular ).toBe( true );
+			expect( state.fetchPending.popular ).toBe( true );
 		} );
 	} );
 


### PR DESCRIPTION
@egardner We only have 2 fairly limited cases for messages: a fetch failure message in the CardStack component and toast notifications in App. We could have included the UserMessages in the state too to remove some of the logic and markup in CardStack, but I decided not to do that in this PR. It's not quite the centralized messaging system I envisioned, but I think it's sufficient for this app. Feedback on this is very welcome though.

Toasts need to be a bit more flexible since there could, in theory, be more than 1 at a time if a user publishes tags very quickly (unlikely). The CardStack message can really only be one thing at a time, so that part of the store is simpler.

The benefit of pulling toast notifications into state is that we can simplify the `publishStatus` state element, which used to hold a string representing the status of publishing tags, to `publishPending`, which is a boolean value reflecting whether or not we should see the publish pending UI.

I'm having trouble with the new actions test `Handles fetch errors successfully` – would you mind taking a look at this and helping me fix it?