### PR TITLE
Add a basic event logging plugin

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -261,6 +261,7 @@
 				"widgets/EntityAutocompleteInputWidget.js",
 				"widgets/UserMessage.js",
 				"plugins/api.js",
+				"plugins/logger.js",
 				"store/index.js",
 				"store/state.js",
 				"store/mutations.js",

--- a/resources/components/App.vue
+++ b/resources/components/App.vue
@@ -9,7 +9,7 @@
 					v-bind:duration="message.duration"
 					v-on:leave="onToastLeave"
 				>
-					<p>{{ $i18n( toast.messageKey ) }}</p>
+					<p>{{ $i18n( message.messageKey ) }}</p>
 				</mw-toast-notification>
 			</template>
 

--- a/resources/components/ImageCard.vue
+++ b/resources/components/ImageCard.vue
@@ -189,7 +189,7 @@ module.exports = {
 				} ).join( ', ' ),
 				imgUrl: this.thumbUrl,
 				imgTitle: this.imgTitle
-			} ).connect( this, { confirm: 'publishTags' } );
+			} ).connect( this, { confirm: 'onFinalConfirm' } );
 
 			this.$logEvent( {
 				action: 'publish',
@@ -199,6 +199,18 @@ module.exports = {
 
 			this.windowManager.addWindows( [ this.confirmTagsDialog ] );
 			this.windowManager.openWindow( this.confirmTagsDialog );
+		},
+
+		/**
+		 * Log an event and dispatch publishTags action.
+		 */
+		onFinalConfirm: function () {
+			this.$logEvent( {
+				action: 'confirm',
+				// eslint-disable-next-line camelcase
+				approved_count: this.confirmedSuggestions.length
+			} );
+			this.publishTags();
 		},
 
 		/**

--- a/resources/components/ImageCard.vue
+++ b/resources/components/ImageCard.vue
@@ -191,6 +191,12 @@ module.exports = {
 				imgTitle: this.imgTitle
 			} ).connect( this, { confirm: 'publishTags' } );
 
+			this.$logEvent( {
+				action: 'publish',
+				// eslint-disable-next-line camelcase
+				approved_count: this.confirmedSuggestions.length
+			} );
+
 			this.windowManager.addWindows( [ this.confirmTagsDialog ] );
 			this.windowManager.openWindow( this.confirmTagsDialog );
 		},
@@ -199,6 +205,7 @@ module.exports = {
 		 * Skip the image (remove it from the Vuex queue).
 		 */
 		onSkip: function () {
+			this.$logEvent( { action: 'skip' } );
 			this.skipImage();
 		},
 

--- a/resources/init.js
+++ b/resources/init.js
@@ -4,6 +4,7 @@
 	var Vue = require( 'vue' ),
 		App = require( './components/App.vue' ),
 		api = require( './plugins/api.js' ),
+		logger = require( './plugins/logger.js' ),
 		store = require( './store/index.js' );
 
 	// Remove placeholder UI
@@ -16,6 +17,7 @@
 	 * https://vuejs.org/v2/guide/plugins.html
 	 */
 	Vue.use( api );
+	Vue.use( logger );
 
 	// Create the Vue instance
 	// eslint-disable-next-line no-new

--- a/resources/plugins/logger.js
+++ b/resources/plugins/logger.js
@@ -1,0 +1,37 @@
+'use strict';
+
+/**
+ * This is a basic example of a Vue plugin. Plugins add global functionality to
+ * Vue. This can be done in several ways: adding global methods or properties,
+ * adding custom directives that can be used in templates ("v-whatever"),
+ * adding component options via global mixin, and adding instance methods to
+ * all Vue components.
+ *
+ * More information about Vue plugins is available here:
+ * https://vuejs.org/v2/guide/plugins.html
+ */
+module.exports = {
+	/**
+	 * @param {Object} Vue constructor
+	 */
+	install: function ( Vue ) {
+		/**
+		 * Log a user interaction event.
+		 * @param {Object} data
+		 * @return {jQuery.Promise} jQuery Promise object for the logging call.
+		 */
+		Vue.prototype.$logEvent = function ( data ) {
+			/* eslint-disable camelcase */
+			var event = $.extend( {}, data, {
+				image_title: this.$store.getters.currentImageTitle,
+				suggestions_count: this.$store.getters.currentImageSuggestions,
+				is_mobile: mw.config.get( 'skin' ) === 'minerva',
+				tab: this.$store.state.currentTab,
+				user_id: mw.user.getId()
+			} );
+			/* eslint-enable camelcase */
+
+			return mw.eventLog.logEvent( 'SuggestedTagsAction', event );
+		};
+	}
+};

--- a/resources/plugins/logger.js
+++ b/resources/plugins/logger.js
@@ -22,13 +22,14 @@ module.exports = {
 		 */
 		Vue.prototype.$logEvent = function ( data ) {
 			/* eslint-disable camelcase */
-			var event = $.extend( {}, data, {
-				image_title: this.$store.getters.currentImageTitle,
-				suggestions_count: this.$store.getters.currentImageSuggestions,
-				is_mobile: mw.config.get( 'skin' ) === 'minerva',
-				tab: this.$store.state.currentTab,
-				user_id: mw.user.getId()
-			} );
+			var currentTab = this.$store.state.currentTab,
+				event = $.extend( {}, data, {
+					image_title: this.$store.getters.currentImageTitle,
+					suggestions_count: this.$store.getters.currentImageSuggestions.length,
+					is_mobile: mw.config.get( 'skin' ) === 'minerva',
+					tab: currentTab === 'user' ? 'personal' : currentTab,
+					user_id: mw.user.getId()
+				} );
 			/* eslint-enable camelcase */
 
 			return mw.eventLog.logEvent( 'SuggestedTagsAction', event );

--- a/tests/jest/ImageCard.test.js
+++ b/tests/jest/ImageCard.test.js
@@ -2,11 +2,13 @@ const VueTestUtils = require( '@vue/test-utils' );
 const Vuex = require( 'vuex' );
 const ImageCard = require( '../../resources/components/ImageCard.vue' );
 const i18n = require( './plugins/i18n' );
+const logger = require( '../../resources/plugins/logger.js' );
 const imageFixtures = require( './fixtures/imageData.json' );
 
 const localVue = VueTestUtils.createLocalVue();
 localVue.use( i18n );
 localVue.use( Vuex );
+localVue.use( logger );
 
 // The ImageCard template creates a Suggestion component with some message-based
 // props (title, text). These props are required, but the messages are not
@@ -16,6 +18,8 @@ localVue.use( Vuex );
 const $i18n = jest.fn().mockReturnValue( {
 	parse: jest.fn().mockReturnValue( 'message' )
 } );
+
+const $logEvent = jest.fn().mockResolvedValue( {} );
 
 describe( 'ImageCard', () => {
 	let state,
@@ -90,7 +94,7 @@ describe( 'ImageCard', () => {
 			confirmedSuggestion
 		] );
 
-		const wrapper = VueTestUtils.mount( ImageCard, { store, localVue, mocks: { $i18n } } );
+		const wrapper = VueTestUtils.mount( ImageCard, { store, localVue, mocks: { $i18n, $logEvent } } );
 		const publishButton = wrapper.find( '.wbmad-action-buttons__publish' );
 		expect( actions.publishTags ).not.toHaveBeenCalled();
 
@@ -103,12 +107,47 @@ describe( 'ImageCard', () => {
 		getters.currentImage.mockReturnValue( imageFixtures[ 0 ] );
 		getters.currentImageSuggestions.mockReturnValue( imageFixtures[ 0 ].suggestions );
 
-		const wrapper = VueTestUtils.mount( ImageCard, { store, localVue, mocks: { $i18n } } );
+		const wrapper = VueTestUtils.mount( ImageCard, { store, localVue, mocks: { $i18n, $logEvent } } );
 		const skipButton = wrapper.find( '.wbmad-action-buttons__skip' );
 
 		expect( actions.skipImage ).not.toHaveBeenCalled();
 
 		skipButton.trigger( 'click' );
 		expect( actions.skipImage ).toHaveBeenCalled();
+	} );
+
+	it( 'logs a "publish" event when the publish button is clicked', () => {
+		let unconfirmedSuggestion = imageFixtures[ 0 ].suggestions[ 0 ];
+		let confirmedSuggestion = imageFixtures[ 0 ].suggestions[ 1 ];
+		confirmedSuggestion.confirmed = true;
+
+		getters.currentImage.mockReturnValue( imageFixtures[ 0 ] );
+		getters.currentImageSuggestions.mockReturnValue( [
+			unconfirmedSuggestion,
+			confirmedSuggestion
+		] );
+
+		const wrapper = VueTestUtils.mount( ImageCard, { store, localVue, mocks: { $i18n, $logEvent } } );
+		const publishButton = wrapper.find( '.wbmad-action-buttons__publish' );
+
+		publishButton.trigger( 'click' );
+		expect( $logEvent ).toHaveBeenCalledWith(
+			expect.objectContaining( { action: 'publish' } )
+		);
+	} );
+
+	it( 'logs a "skip" event when the  skip button is clicked', () => {
+		getters.currentImage.mockReturnValue( imageFixtures[ 0 ] );
+		getters.currentImageSuggestions.mockReturnValue( imageFixtures[ 0 ].suggestions );
+
+		const wrapper = VueTestUtils.mount( ImageCard, { store, localVue, mocks: { $i18n, $logEvent } } );
+		const skipButton = wrapper.find( '.wbmad-action-buttons__skip' );
+
+		expect( actions.skipImage ).not.toHaveBeenCalled();
+
+		skipButton.trigger( 'click' );
+		expect( $logEvent ).toHaveBeenCalledWith(
+			expect.objectContaining( { action: 'skip' } )
+		);
 	} );
 } );


### PR DESCRIPTION
* Adds a logger plugin which adds a single method to all components: $logEvent;
  The plugin contains all references to the global mw object and pulls
  necessary data out of Vuex; all the caller must do is provide the action
* Calls this method in the publish and skip handlers of ImageCard.vue
* Adds tests for this new functionality

Change-Id: Iefd39354db5538f4db3769b9ab034fdcf9a15ae5